### PR TITLE
Allow Admin to Bypass Reservation Time Restriction

### DIFF
--- a/src/controllers/reservations_controllers.js
+++ b/src/controllers/reservations_controllers.js
@@ -8,8 +8,8 @@ const UserFinance = require('../models/finances');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const TelegramBot = require('node-telegram-bot-api');
-const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
-const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
+// const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
+// const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
 const ADMIN_CHAT_ID = '6558646628';
 
 
@@ -190,7 +190,7 @@ exports.getUserReservations_ = (req, res) => {
 
 
 exports.createReservation = async (req, res) => {
-  const { userId, day, dayOfWeek, hour } = req.body;
+  const { userId, day, dayOfWeek, hour, isAdmin = false  } = req.body;
 
   try {
     // Validación básica de campos
@@ -230,12 +230,13 @@ exports.createReservation = async (req, res) => {
     const now = moment.tz('America/Bogota');
     const timeDifference = reservationDateTime.diff(now, 'minutes');
 
-    if (existingReservationsCount === 0 && timeDifference < 60) {
+    if (!isAdmin && existingReservationsCount === 0 && timeDifference < 60) {
       return res.status(400).json({
         code: 'TIME_RESTRICTION',
         message: 'Solo puedes reservar con al menos una hora de antelación si no hay reservas previas.'
       });
     }
+
     
 
     // Crear nueva reserva
@@ -244,7 +245,8 @@ exports.createReservation = async (req, res) => {
       day,
       dayOfWeek,
       hour,
-      Attendance: 'Si'
+      Attendance: 'Si',
+      isAdmin
     });
 
     const savedReservation = await newReservation.save();

--- a/src/models/reservations.js
+++ b/src/models/reservations.js
@@ -7,7 +7,8 @@ const reservationSchema = new mongoose.Schema({
   hour:{ type: String, required: true },
   TrainingType:String,
   Status:String,
-  Attendance:String
+  Attendance:String,
+  isAdmin:Boolean
 
 });
 


### PR DESCRIPTION
# 🛠️ Backend - Allow Admin to Bypass Reservation Time Restriction

## 📋 Description

This update adds logic to the backend to allow administrators to create reservations for users **without being restricted by the 1-hour advance notice rule**, which normally applies if no prior reservations exist for the selected time slot.

## ✅ Key Changes

- The `Reservation` model now includes a new field: `isAdmin` (Boolean) to indicate whether the reservation was created by an admin.
- The `createReservation` controller now accepts `isAdmin` from the request body.
- The 1-hour time restriction is skipped **only** if `isAdmin` is `true`.
- The `isAdmin` flag is stored in the database along with the reservation for tracking purposes.

## 🧪 Testing

- Tested with `isAdmin: false` → Restriction applied as expected when no prior reservations exist and the time is less than 60 minutes away.
- Tested with `isAdmin: true` → Admin is allowed to reserve for another user at any time regardless of the restriction.
- Confirmed that the `isAdmin` field is correctly saved in the reservation document.

## 🔄 Example Request Body

```json
{
  "userId": "64abc123...",
  "day": "2025-07-01",
  "dayOfWeek": "Tuesday",
  "hour": "08:00",
  "isAdmin": true
}
