### PR TITLE
add a telegrem bot

### DIFF
--- a/src/controllers/reservations_controllers.js
+++ b/src/controllers/reservations_controllers.js
@@ -8,8 +8,8 @@ const UserFinance = require('../models/finances');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const TelegramBot = require('node-telegram-bot-api');
-// const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
-// const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
+const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
+const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
 const ADMIN_CHAT_ID = '6558646628';
 
 


### PR DESCRIPTION
# 🔔 Reactivate Telegram Notification Bot

## 📋 Description

This pull request re-enables the Telegram bot used for sending reservation notifications to the admin. The bot was previously disabled for testing purposes and is now fully reactivated.

## ✅ Key Changes

- Restored the Telegram bot logic in the reservation controller.
- Admins will once again receive instant reservation notifications via Telegram upon successful booking.

---