### PR TITLE
add dinamic request in finaces and store

### DIFF
--- a/src/controllers/finances_controllers.js
+++ b/src/controllers/finances_controllers.js
@@ -149,14 +149,28 @@ exports.updateFinanceById = async (req, res) => {
   }
 };
 
-exports.getAllUsersFinances = (req, res) => {
-  UserFinance.find()
-    .then((users) => {
-      res.json(users);
-    })
-    .catch((error) => {
-      res.status(500).json({ error: 'Error al obtener la información de los usuarios' });
-    });
+exports.getAllUsersFinances = async (req, res) => {
+  try {
+    const { date } = req.query;
+    const referenceDate = date
+      ? moment(date, ['YYYY-MM', 'YYYY-MM-DD'], true)
+      : moment();
+
+    if (!referenceDate.isValid()) {
+      return res.status(400).json({ error: 'Formato de fecha inválido. Usa YYYY-MM o YYYY-MM-DD.' });
+    }
+
+    const startRange = referenceDate.clone().subtract(1, 'month').startOf('month').format('YYYY-MM-DD');
+    const endRange = referenceDate.clone().add(1, 'month').endOf('month').format('YYYY-MM-DD');
+
+    const users = await UserFinance.find({
+      startDate: { $gte: startRange, $lte: endRange }
+    }).sort({ startDate: -1 });
+
+    res.json(users);
+  } catch (error) {
+    res.status(500).json({ error: 'Error al obtener la información de los usuarios' });
+  }
 };
 exports.getAllDiaryUsersFinances = (req, res) => {
 
@@ -215,4 +229,3 @@ exports.deleteFiance = (req, res) => {
       res.status(500).json({ error: 'Error al eliminar usuario' });
     });
 };
-

--- a/src/controllers/reservations_controllers.js
+++ b/src/controllers/reservations_controllers.js
@@ -11,20 +11,20 @@ const Invitado = require('../models/invitados');
 const mongoose = require('mongoose');
 const moment = require('moment');
 const TelegramBot = require('node-telegram-bot-api');
-//const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
-//const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
+const TELEGRAM_TOKEN = '7409507098:AAEJ_Nb1tFXcKmRExxrTaYUD6j_ntLjjAaI'; // Bullbot
+const bot = new TelegramBot(TELEGRAM_TOKEN, { polling: true });
 const ADMIN_CHAT_ID = '6558646628';
 const ADMIN_USER_ID = '65b217209cf3fba40530ac09';
 
 const startProfiler = (label) => {
   const profilerLabel = `${label}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
-  console.time(profilerLabel);
+  //console.time(profilerLabel);
   return profilerLabel;
 };
 
 const endProfiler = (label) => {
   if (label) {
-    console.timeEnd(label);
+    //console.timeEnd(label);
   }
 };
 

--- a/src/controllers/store_controller.js
+++ b/src/controllers/store_controller.js
@@ -77,7 +77,22 @@ exports.updateStoreConsumption = async (req, res) => {
 
 exports.getAllStoreConsumptions = async (req, res) => {
   try {
-    const consumptions = await UserStore.find();
+    const { date } = req.query;
+    const referenceDate = date
+      ? moment.tz(date, ['YYYY-MM', 'YYYY-MM-DD'], 'America/Bogota', true)
+      : moment().tz('America/Bogota');
+
+    if (!referenceDate.isValid()) {
+      return res.status(400).json({ error: 'Formato de fecha inválido. Usa YYYY-MM o YYYY-MM-DD.' });
+    }
+
+    const startRange = referenceDate.clone().subtract(1, 'month').startOf('month').format('YYYY-MM-DD');
+    const endRange = referenceDate.clone().add(1, 'month').endOf('month').format('YYYY-MM-DD');
+
+    const consumptions = await UserStore.find({
+      dateOfPurchase: { $gte: startRange, $lte: endRange }
+    }).sort({ dateOfPurchase: -1, purchaseTime: -1 });
+
     res.json(consumptions);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
### Description:
Main changes:

src/controllers/store_controller.js (line 78): The consumption list now filters using a three-month window (current month ±1). `?date=YYYY-MM` or `YYYY-MM-DD` is supported to set the reference month; invalid dates return 400.
src/controllers/finances_controllers.js (line 152): The finance endpoint applies the same three-month window logic to `startDate`, supports the same `date` parameter, and returns an error when the format is invalid.

Suggested next steps: 1) Adjust the frontend to send `date` when navigating between months in store/finances. 2) If longer periods need to be queried, extend the API with parameters such as `rangeMonths`.
