### PR TITLE
feat(auth): require JWT on 7 routers (PQRS, Invitados, Store, Reserva…

### DIFF
--- a/src/routes/api/finances_routes.js
+++ b/src/routes/api/finances_routes.js
@@ -1,6 +1,14 @@
 const express = require('express');
 const router = express.Router();
 const financesController = require('../../controllers/finances_controllers');
+const { requireAuth } = require('../../middleware/auth');
+
+// Sprint 3.C.2: all finance endpoints now require a valid JWT.
+// Note: horizontal authorization (a non-admin user cannot read another
+// user's finances) is intentionally NOT enforced in this commit. Today
+// the bar is just "must be logged in". Sprint 3.E will add the
+// requireSelfOrAdmin check to /finances/:userId style routes.
+router.use(requireAuth);
 
 router.post('/finances', financesController.financesUser);
 router.put('/userFinance/:userId', financesController.updateFinanceByUserId);

--- a/src/routes/api/invitados_routes.js
+++ b/src/routes/api/invitados_routes.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const invitadosController = require('../../controllers/invitados_controller');
+const { requireAuth } = require('../../middleware/auth');
+
+// Sprint 3.C.2: all guest-pass endpoints now require a valid JWT.
+router.use(requireAuth);
 
 router.get('/invitados', invitadosController.getAllInvitados);
 router.get('/invitados/usuario/:userId', invitadosController.getInvitadosByUser);

--- a/src/routes/api/pqrs_routes.js
+++ b/src/routes/api/pqrs_routes.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const pqrsController = require('../../controllers/pqrs_controllers');
+const { requireAuth } = require('../../middleware/auth');
 
+// Sprint 3.C.2: every PQRS endpoint now requires a valid JWT. Anonymous
+// callers receive 401. The frontend interceptor (setupApiAuth) attaches
+// the token automatically when one is stored.
+router.use(requireAuth);
 
 router.post('/pqr', pqrsController.createPqr);
 router.get('/pqrs', pqrsController.getPqrs);

--- a/src/routes/api/prices_routes.js
+++ b/src/routes/api/prices_routes.js
@@ -1,6 +1,13 @@
 const express = require('express');
 const router = express.Router();
 const pricesController = require('../../controllers/prices_controller');
+const { requireAuth } = require('../../middleware/auth');
+
+// Sprint 3.C.2: all prices endpoints now require a valid JWT. Reading the
+// price catalog is needed by every authenticated user (it's surfaced when
+// computing daily-plan totals), so requireAuth is the right level here.
+// Sprint 3.E may upgrade write endpoints (POST/PUT/DELETE) to requireAdmin.
+router.use(requireAuth);
 
 router.post('/prices', pricesController.createPrice);
 router.get('/prices', pricesController.getAllPrices);

--- a/src/routes/api/quotaLimits_routes.js
+++ b/src/routes/api/quotaLimits_routes.js
@@ -2,7 +2,13 @@
 const express = require('express');
 const router = express.Router();
 const slotController = require('../../controllers/quotaLimits_controller');
+const { requireAuth } = require('../../middleware/auth');
 
+// Sprint 3.C.2: every quota/slot endpoint now requires a valid JWT. The
+// reservation flow needs this on every page load so it stays at the
+// requireAuth (not requireAdmin) level. Write endpoints can be elevated
+// to requireAdmin in Sprint 3.E.
+router.use(requireAuth);
 
 router.post('/slots', slotController.createSlot);
 

--- a/src/routes/api/reservations_routes.js
+++ b/src/routes/api/reservations_routes.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const reservationsControllers = require('../../controllers/reservations_controllers');
+const { requireAuth } = require('../../middleware/auth');
+
+// Sprint 3.C.2: all reservation endpoints now require a valid JWT.
+router.use(requireAuth);
 
 router.get('/reservations', reservationsControllers.getAllReservations);
 router.get('/reservations/week', reservationsControllers.getReservationsByWeek);

--- a/src/routes/api/store_routes.js
+++ b/src/routes/api/store_routes.js
@@ -1,6 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const storeController = require('../../controllers/store_controller');
+const { requireAuth } = require('../../middleware/auth');
+
+// Sprint 3.C.2: all store endpoints now require a valid JWT.
+router.use(requireAuth);
 
 router.post('/store', storeController.createStoreConsumption);
 router.put('/store/:id', storeController.updateStoreConsumption);


### PR DESCRIPTION


Sprint 3.C.2.a. With the frontend interceptor (Sprint 3.C.1) shipped and confirmed in production, every authenticated client now sends Authorization: Bearer <token> automatically on every request. So we can finally close the door on anonymous traffic for the bulk of the API surface.

What this commit does:
  - Mounts requireAuth as router-level middleware on: pqrs_routes, invitados_routes, store_routes, reservations_routes, finances_routes, prices_routes, quotaLimits_routes.
  - Anonymous calls (no Authorization, expired token, malformed token) now get 401 instead of 200.

What this commit does NOT do (intentionally):
  - users_routes: deferred to a follow-up commit. Some calls (e.g. GET /users/:userId) need 'self-or-admin' logic that requireAuth alone doesn't enforce. Until then the route stays as-is.
  - termsAndConditions_routes: deferred. The public terms-signing flow may rely on at least one anonymous endpoint; needs a quick audit before we add the middleware.
  - Horizontal authorization on /finances/:userId, /reservations/:userId, etc. Today any authenticated user can read another user's data. Sprint 3.E will add a requireSelfOrAdmin helper and apply it where it matters.

Rollout plan: this branch (feat/protect-routes) gets merged AFTER the Sprint 3.C.1 interceptor is verified live (which it is). If any component breaks because it does not yet send the token, the global fetch patch will catch it - we revisit per case.