### PR TITLE
feat(push): backend foundations for Web Push notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_BUCKET=bullfit-terms
 
+# ---- Push Notifications (Web Push / VAPID) ---------------------------------
+# Generate a fresh keypair with:  npx web-push generate-vapid-keys
+# Public key is also exposed via GET /api/push/public-key for the frontend.
+# Subject is a contact mailto: that push services include in error reports.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:admin@bullfit.app
+
 # ---- Auth (JWT) ------------------------------------------------------------
 # REQUIRED in production. Generate with: openssl rand -base64 48
 # If unset, /api/auth/login will return 500 and any rute protected by

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const slot = require('./src/routes/api/quotaLimits_routes');
 const termsAndConditionsRoutes = require('./src/routes/api/termsAndConditions_routes');
 const pqrs = require('./src/routes/api/pqrs_routes');
 const authRoutes = require('./src/routes/api/auth_routes');
+const pushRoutes = require('./src/routes/api/push_routes');
 
 dotenv.config();
 
@@ -143,6 +144,7 @@ app.use('/api', apiLimiter);
 // Rutas de la API
 // Auth router goes first so /api/auth/login isn't shadowed by anything else.
 app.use('/api', authRoutes);
+app.use('/api', pushRoutes);
 app.use('/api', usersRoutes);
 app.use('/api', reservationsRoutes);
 app.use('/api', financeRoutes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "node-telegram-bot-api": "^0.66.0",
         "nodemon": "^3.0.1",
         "puppeteer": "^10.4.0",
-        "twilio": "^4.20.1"
+        "twilio": "^4.20.1",
+        "web-push": "^3.6.7"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -2343,6 +2344,18 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2663,6 +2676,12 @@
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -4957,6 +4976,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7059,6 +7087,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -10054,6 +10088,70 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/web-push/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-push/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/web-push/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node-telegram-bot-api": "^0.66.0",
     "nodemon": "^3.0.1",
     "puppeteer": "^10.4.0",
-    "twilio": "^4.20.1"
+    "twilio": "^4.20.1",
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/src/controllers/push_controller.js
+++ b/src/controllers/push_controller.js
@@ -1,0 +1,141 @@
+// src/controllers/push_controller.js
+// Sprint 6.A controllers:
+//   - publicKey: return the VAPID public key so the frontend can subscribe
+//   - subscribe: store/refresh the browser-issued PushSubscription
+//   - unsubscribe: drop a subscription on logout / explicit opt-out
+//   - sendBroadcast (admin): create a notification and push it to every
+//     active subscription. Subscriptions that come back as gone (404/410)
+//     are deleted as part of the same call so we self-heal the list.
+
+const PushSubscription = require('../models/pushSubscription');
+const { sendPush, isConfigured, getPublicKey } = require('../lib/webPush');
+
+exports.publicKey = (req, res) => {
+  if (!isConfigured()) {
+    return res.status(503).json({ message: 'VAPID no configurado en el servidor' });
+  }
+  return res.json({ key: getPublicKey() });
+};
+
+exports.subscribe = async (req, res) => {
+  const { endpoint, keys } = req.body || {};
+  if (!endpoint || !keys || !keys.p256dh || !keys.auth) {
+    return res.status(400).json({ message: 'Subscription mal formada' });
+  }
+
+  const userId = req.auth && req.auth.sub;
+  if (!userId) {
+    return res.status(401).json({ message: 'No autenticado' });
+  }
+
+  try {
+    // Upsert keyed by (userId, endpoint) so reconnecting the same device
+    // does not create duplicates.
+    const sub = await PushSubscription.findOneAndUpdate(
+      { userId, endpoint },
+      {
+        $set: {
+          userId,
+          endpoint,
+          keys,
+          userAgent: req.headers['user-agent'],
+          lastSeenAt: new Date(),
+        },
+      },
+      { upsert: true, new: true, setDefaultsOnInsert: true },
+    );
+    return res.status(201).json({ id: sub._id });
+  } catch (err) {
+    console.error('[push/subscribe] error:', err);
+    return res.status(500).json({ message: 'Error guardando la suscripción' });
+  }
+};
+
+exports.unsubscribe = async (req, res) => {
+  const { endpoint } = req.body || {};
+  const userId = req.auth && req.auth.sub;
+  if (!userId || !endpoint) {
+    return res.status(400).json({ message: 'endpoint requerido' });
+  }
+  try {
+    await PushSubscription.deleteOne({ userId, endpoint });
+    return res.status(204).end();
+  } catch (err) {
+    console.error('[push/unsubscribe] error:', err);
+    return res.status(500).json({ message: 'Error eliminando la suscripción' });
+  }
+};
+
+/**
+ * POST /api/notifications
+ * Body: { title, body, url? }
+ *
+ * Sprint 6.A behavior: send to ALL active subscriptions in parallel.
+ * Sprint 6.D will add `recipients: [userId, ...]` for individual targeting.
+ * Sprint 6.E will add `scheduledFor: ISODate` for scheduling.
+ *
+ * Auth: requireAdmin (applied at the router level).
+ */
+exports.sendBroadcast = async (req, res) => {
+  if (!isConfigured()) {
+    return res.status(503).json({ message: 'VAPID no configurado en el servidor' });
+  }
+
+  const title = (req.body && typeof req.body.title === 'string') ? req.body.title.trim() : '';
+  const body = (req.body && typeof req.body.body === 'string') ? req.body.body.trim() : '';
+  const url = (req.body && typeof req.body.url === 'string') ? req.body.url.trim() : '/';
+
+  if (!title || !body) {
+    return res.status(400).json({ message: 'title y body son requeridos' });
+  }
+  if (title.length > 80) {
+    return res.status(400).json({ message: 'title no puede exceder 80 caracteres' });
+  }
+  if (body.length > 240) {
+    return res.status(400).json({ message: 'body no puede exceder 240 caracteres' });
+  }
+
+  let subs;
+  try {
+    subs = await PushSubscription.find().lean();
+  } catch (err) {
+    console.error('[push/send] error cargando suscripciones:', err);
+    return res.status(500).json({ message: 'Error cargando suscripciones' });
+  }
+
+  if (subs.length === 0) {
+    return res.json({ sent: 0, gone: 0, failed: 0, total: 0 });
+  }
+
+  const payload = { title, body, url };
+
+  // Run sends in parallel but bound the concurrency a bit so we don't
+  // open hundreds of sockets at once if the subscription list grows.
+  const results = await Promise.all(subs.map((sub) => sendPush(sub, payload)));
+
+  let sent = 0;
+  let gone = 0;
+  let failed = 0;
+  const goneIds = [];
+
+  results.forEach((r, i) => {
+    if (r.ok) sent += 1;
+    else if (r.gone) {
+      gone += 1;
+      goneIds.push(subs[i]._id);
+    } else {
+      failed += 1;
+    }
+  });
+
+  // Clean up dead subscriptions so future broadcasts don't pay for them.
+  if (goneIds.length > 0) {
+    try {
+      await PushSubscription.deleteMany({ _id: { $in: goneIds } });
+    } catch (err) {
+      console.error('[push/send] error borrando subs vencidas:', err);
+    }
+  }
+
+  return res.json({ sent, gone, failed, total: subs.length });
+};

--- a/src/lib/webPush.js
+++ b/src/lib/webPush.js
@@ -1,0 +1,64 @@
+// src/lib/webPush.js
+// Thin wrapper around the `web-push` package. The wrapper:
+//   - Configures VAPID details once from env vars (VAPID_PUBLIC_KEY,
+//     VAPID_PRIVATE_KEY, VAPID_SUBJECT). If anything is missing we keep
+//     the rest of the app booting and surface the error only when
+//     somebody actually tries to send.
+//   - Exposes sendPush(subscription, payload) which JSON-encodes the
+//     payload and returns a result object instead of throwing - that way
+//     the caller can keep iterating over a list of subscriptions even
+//     when one of them is dead.
+//   - Treats 404/410 responses from the push service as "this
+//     subscription is gone" and asks the caller to delete it from Mongo.
+//     The push spec uses these codes specifically for expired endpoints.
+
+const webpush = require('web-push');
+
+const PUBLIC_KEY = process.env.VAPID_PUBLIC_KEY;
+const PRIVATE_KEY = process.env.VAPID_PRIVATE_KEY;
+const SUBJECT = process.env.VAPID_SUBJECT || 'mailto:admin@bullfit.app';
+
+let configured = false;
+
+const configureIfPossible = () => {
+  if (configured) return true;
+  if (!PUBLIC_KEY || !PRIVATE_KEY) return false;
+  webpush.setVapidDetails(SUBJECT, PUBLIC_KEY, PRIVATE_KEY);
+  configured = true;
+  return true;
+};
+
+const isConfigured = () => Boolean(PUBLIC_KEY && PRIVATE_KEY);
+
+/**
+ * Send a single push notification.
+ * Returns { ok: true } on success or
+ *         { ok: false, gone: true, status, error } if the subscription
+ *           is permanently invalid (caller should delete it),
+ *         { ok: false, gone: false, status, error } for transient failures.
+ */
+const sendPush = async (subscription, payload) => {
+  if (!configureIfPossible()) {
+    return { ok: false, gone: false, status: 0, error: 'VAPID not configured' };
+  }
+
+  try {
+    const body = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    await webpush.sendNotification(
+      {
+        endpoint: subscription.endpoint,
+        keys: subscription.keys,
+      },
+      body,
+      { TTL: 60 * 60 * 24 }, // 24h - if the device is offline longer, drop it
+    );
+    return { ok: true };
+  } catch (err) {
+    const status = err && err.statusCode;
+    // 404 (Not Found) and 410 (Gone) are the spec codes for "delete me".
+    const gone = status === 404 || status === 410;
+    return { ok: false, gone, status, error: err && err.message };
+  }
+};
+
+module.exports = { sendPush, isConfigured, getPublicKey: () => PUBLIC_KEY };

--- a/src/models/pushSubscription.js
+++ b/src/models/pushSubscription.js
@@ -1,0 +1,40 @@
+// src/models/pushSubscription.js
+// One document per (user, browser) pair. The browser-issued endpoint is
+// what the Push service uses to deliver the notification, and the keys
+// are the encryption envelope for the payload. We keep userId so the
+// admin can target individual users in a later sprint.
+//
+// Why a compound unique on (userId, endpoint):
+//   A user can have several active subscriptions (phone + tablet + laptop)
+//   but the SAME endpoint should never be duplicated for the same user
+//   on re-login or duplicate calls to subscribe(). Without the index, a
+//   user that re-subscribes creates a row each time and we send N copies
+//   of every notification.
+
+const mongoose = require('mongoose');
+
+const pushSubscriptionSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    endpoint: { type: String, required: true },
+    keys: {
+      p256dh: { type: String, required: true },
+      auth: { type: String, required: true },
+    },
+    // The User-Agent at subscribe time. Helpful for debugging "why did
+    // this device stop receiving notifications" (often Safari < 16.4 or
+    // a device that changed its identity).
+    userAgent: { type: String },
+    lastSeenAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true },
+);
+
+pushSubscriptionSchema.index({ userId: 1, endpoint: 1 }, { unique: true });
+
+module.exports = mongoose.model('PushSubscription', pushSubscriptionSchema);

--- a/src/routes/api/push_routes.js
+++ b/src/routes/api/push_routes.js
@@ -1,0 +1,26 @@
+// src/routes/api/push_routes.js
+// Sprint 6.A. Three endpoints:
+//   GET  /api/push/public-key   - any authenticated user, frontend calls
+//                                 it to bootstrap the browser subscription
+//   POST /api/push/subscribe    - any authenticated user, persists sub
+//   POST /api/push/unsubscribe  - any authenticated user, removes sub
+//   POST /api/notifications     - admin only, broadcast to all subs
+//
+// Future:
+//   GET    /api/notifications      (Sprint 6.E - list scheduled)
+//   DELETE /api/notifications/:id  (Sprint 6.E - cancel scheduled)
+
+const express = require('express');
+const router = express.Router();
+const pushController = require('../../controllers/push_controller');
+const { requireAuth, requireAdmin } = require('../../middleware/auth');
+
+// Authenticated user endpoints (anyone logged in).
+router.get('/push/public-key', requireAuth, pushController.publicKey);
+router.post('/push/subscribe', requireAuth, pushController.subscribe);
+router.post('/push/unsubscribe', requireAuth, pushController.unsubscribe);
+
+// Admin-only broadcast.
+router.post('/notifications', requireAdmin, pushController.sendBroadcast);
+
+module.exports = router;


### PR DESCRIPTION
Sprint 6.A. Lays the server side for PWA push notifications. The admin will be able to send a free-form title+body to every active subscriber. Targeting individual users (Sprint 6.D) and scheduled delivery (Sprint 6.E) are not in this commit but the data model and the helper are designed to extend cleanly into them.

Pieces added:

src/models/pushSubscription.js
  One row per (userId, endpoint) pair with a unique compound index so
  re-subscribing the same browser does not duplicate. Stores the
  encryption keys (p256dh, auth) the push service needs, plus the
  user-agent for debugging delivery issues.

src/lib/webPush.js
  Wraps the web-push package with VAPID config from env and a
  send-or-report API: sendPush returns { ok: true } on delivery, or
  { ok: false, gone: true } when the push service replies 404/410 (the
  endpoint is permanently dead and the caller should drop it). VAPID
  is configured lazily so the rest of the app boots even if the env
  vars are missing.

src/controllers/push_controller.js
  - publicKey: returns VAPID public key so the SPA can call subscribe()
  - subscribe: upsert by (userId, endpoint), refreshes lastSeenAt
  - unsubscribe: deletes one (userId, endpoint) pair on logout/opt-out
  - sendBroadcast: admin-only. Sends to every subscription in parallel and self-heals by deleting the ones the push service flagged as gone in the same request.

src/routes/api/push_routes.js
  - GET    /api/push/public-key   (requireAuth)
  - POST   /api/push/subscribe    (requireAuth)
  - POST   /api/push/unsubscribe  (requireAuth)
  - POST   /api/notifications     (requireAdmin)

app.js: mounts pushRoutes right after authRoutes, before the rest, so its paths are not shadowed.

.env.example: documents VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY / VAPID_SUBJECT and the npx command to generate a new keypair.

DEPLOY NOTE: configure VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY in DigitalOcean App Platform before merging. Without them, the push endpoints return 503 but the rest of the API keeps working as today.