### PR TITLE
feat: notification templates, stats fixes, app.bullfit.co CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -21,6 +21,7 @@ const authRoutes = require('./src/routes/api/auth_routes');
 const pushRoutes = require('./src/routes/api/push_routes');
 const statsRoutes = require('./src/routes/api/stats_routes');
 const gamificationRoutes = require('./src/routes/api/gamification_routes');
+const leadsRoutes = require('./src/routes/api/leads_routes');
 const { startInactivityJob } = require('./src/jobs/inactivityJob');
 
 dotenv.config();
@@ -90,6 +91,9 @@ db.once('open', () => {
 const PROD_ORIGINS = [
   'https://bullfit-app-v2-0.vercel.app',
   'https://app.bullfit.co',
+  // Public landing — posts new leads to POST /api/leads.
+  'https://bullfit.co',
+  'https://www.bullfit.co',
 ];
 const VERCEL_PREVIEW_REGEX = /^https:\/\/bullfit-app-v2-0(-[a-z0-9-]+)?\.vercel\.app$/i;
 const LOCAL_DEV_ORIGINS = [
@@ -157,6 +161,9 @@ app.use('/api', apiLimiter);
 // Rutas de la API
 // Auth router goes first so /api/auth/login isn't shadowed by anything else.
 app.use('/api', authRoutes);
+// Leads BEFORE the routers that apply router-level requireAuth, so the public
+// POST /api/leads (landing form) isn't swallowed by their global guard.
+app.use('/api', leadsRoutes);
 // Stats route before authenticated routers (has its own password gate in frontend).
 app.use('/api', statsRoutes);
 app.use('/api', pushRoutes);

--- a/app.js
+++ b/app.js
@@ -20,6 +20,8 @@ const pqrs = require('./src/routes/api/pqrs_routes');
 const authRoutes = require('./src/routes/api/auth_routes');
 const pushRoutes = require('./src/routes/api/push_routes');
 const statsRoutes = require('./src/routes/api/stats_routes');
+const gamificationRoutes = require('./src/routes/api/gamification_routes');
+const { startInactivityJob } = require('./src/jobs/inactivityJob');
 
 dotenv.config();
 
@@ -66,7 +68,10 @@ const db = mongoose.connection;
 db.on('error', (error) => console.error('MongoDB error:', error));
 db.on('disconnected', () => console.warn('MongoDB disconnected'));
 db.on('reconnected', () => console.log('MongoDB reconnected'));
-db.once('open', () => console.log('Conexión a la base de datos exitosa'));
+db.once('open', () => {
+  console.log('Conexión a la base de datos exitosa');
+  startInactivityJob();
+});
 
 
 // ---- CORS ------------------------------------------------------------------
@@ -80,31 +85,38 @@ db.once('open', () => console.log('Conexión a la base de datos exitosa'));
 // (https://bullfit-app-v2-0-*-santiagomurilloval.vercel.app) without
 // relaxing security to "*". Requests with no Origin header (server-to-server,
 // curl, mobile webviews) are allowed through to keep existing flows working.
-const PROD_VERCEL_ORIGIN = 'https://bullfit-app-v2-0.vercel.app';
+// Stable production frontends. Both keep working side by side: the original
+// Vercel domain and the new custom domain (app.bullfit.co).
+const PROD_ORIGINS = [
+  'https://bullfit-app-v2-0.vercel.app',
+  'https://app.bullfit.co',
+];
 const VERCEL_PREVIEW_REGEX = /^https:\/\/bullfit-app-v2-0(-[a-z0-9-]+)?\.vercel\.app$/i;
 const LOCAL_DEV_ORIGINS = [
   'http://localhost:3000',
   'http://127.0.0.1:3000',
 ];
 
+// CORS_ORIGINS (if set) is now ADDITIVE on top of the built-in allow list,
+// instead of replacing it. This guarantees the known production frontends keep
+// working even if the env var is set to something narrower.
 const explicitWhitelist = process.env.CORS_ORIGINS
   ? process.env.CORS_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
-  : null;
+  : [];
+
+const isAllowedOrigin = (origin) => {
+  if (PROD_ORIGINS.includes(origin)) return true;
+  if (VERCEL_PREVIEW_REGEX.test(origin)) return true;
+  if (LOCAL_DEV_ORIGINS.includes(origin)) return true;
+  if (explicitWhitelist.includes(origin)) return true;
+  return false;
+};
 
 app.use(cors({
   origin: (origin, callback) => {
     // Allow same-origin / non-browser callers (no Origin header).
     if (!origin) return callback(null, true);
-
-    if (explicitWhitelist) {
-      return callback(null, explicitWhitelist.includes(origin));
-    }
-
-    if (origin === PROD_VERCEL_ORIGIN) return callback(null, true);
-    if (VERCEL_PREVIEW_REGEX.test(origin)) return callback(null, true);
-    if (LOCAL_DEV_ORIGINS.includes(origin)) return callback(null, true);
-
-    return callback(null, false);
+    return callback(null, isAllowedOrigin(origin));
   },
   credentials: true,
 }));
@@ -158,6 +170,7 @@ app.use('/api', termsAndConditionsRoutes);
 app.use('/api', slot);
 app.use('/api', pqrs);
 app.use('/api', invitadosRoutes);
+app.use('/api', gamificationRoutes);
 
 // ---- 404 handler -----------------------------------------------------------
 // Anything that wasn't caught by the routers above. Keep before the error

--- a/src/controllers/gamification_controller.js
+++ b/src/controllers/gamification_controller.js
@@ -1,0 +1,159 @@
+// src/controllers/gamification_controller.js
+// Endpoints for the Bullfit gamification system:
+//   GET  /api/gamification/:userId          - streak + calendar for a user
+//   GET  /api/gamification/:userId/streak   - streak data only (lightweight)
+//   GET  /api/user-notifications            - bell inbox for the logged-in user
+//   PATCH /api/user-notifications/:id/read  - mark one notification as read
+//   PATCH /api/user-notifications/read-all  - mark all as read
+//   DELETE /api/user-notifications/:id      - delete one notification
+//   DELETE /api/user-notifications/all      - delete all for user
+
+const moment = require('moment-timezone');
+const UserStreak = require('../models/userStreak');
+const UserNotification = require('../models/userNotification');
+const { computeStreak, buildCalendarMonth } = require('../services/gamificationService');
+
+const TZ = 'America/Bogota';
+
+// ─── Streak + Calendar ───────────────────────────────────────────────────────
+
+/**
+ * GET /api/gamification/:userId
+ * Query params: ?year=2026&month=6   (defaults to current month)
+ *
+ * Returns streak data + calendar grid for the requested month.
+ */
+exports.getUserGamification = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const now = moment.tz(TZ);
+    const year = Number(req.query.year) || now.year();
+    const month = Number(req.query.month) || now.month() + 1; // 1-based
+
+    // Try cached streak first; fall back to live computation.
+    let streak = await UserStreak.findOne({ userId }).lean();
+    if (!streak) {
+      streak = await computeStreak(userId);
+    }
+
+    const calendar = await buildCalendarMonth(userId, year, month);
+
+    return res.json({ streak, calendar });
+  } catch (err) {
+    console.error('[gamification] getUserGamification error:', err);
+    return res.status(500).json({ message: 'Error al obtener datos de gamificación' });
+  }
+};
+
+/**
+ * GET /api/gamification/:userId/streak
+ * Lightweight — just streak numbers, no calendar grid.
+ */
+exports.getUserStreak = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    let streak = await UserStreak.findOne({ userId }).lean();
+    if (!streak) {
+      streak = await computeStreak(userId);
+    }
+    return res.json(streak);
+  } catch (err) {
+    console.error('[gamification] getUserStreak error:', err);
+    return res.status(500).json({ message: 'Error al obtener racha' });
+  }
+};
+
+// ─── Notification Bell ───────────────────────────────────────────────────────
+
+/**
+ * GET /api/user-notifications
+ * Returns notifications for the authenticated user.
+ * Query: ?limit=30&offset=0
+ */
+exports.listNotifications = async (req, res) => {
+  try {
+    const userId = req.auth.sub;
+    const limit = Math.min(Number(req.query.limit) || 30, 100);
+    const offset = Number(req.query.offset) || 0;
+
+    const [notifications, unreadCount] = await Promise.all([
+      UserNotification.find({ userId })
+        .sort({ read: 1, createdAt: -1 })
+        .skip(offset)
+        .limit(limit)
+        .lean(),
+      UserNotification.countDocuments({ userId, read: false }),
+    ]);
+
+    return res.json({ notifications, unreadCount });
+  } catch (err) {
+    console.error('[gamification] listNotifications error:', err);
+    return res.status(500).json({ message: 'Error al obtener notificaciones' });
+  }
+};
+
+/**
+ * PATCH /api/user-notifications/read-all
+ * Mark all unread notifications as read for the authenticated user.
+ */
+exports.markAllRead = async (req, res) => {
+  try {
+    const userId = req.auth.sub;
+    await UserNotification.updateMany({ userId, read: false }, { $set: { read: true } });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('[gamification] markAllRead error:', err);
+    return res.status(500).json({ message: 'Error al marcar notificaciones' });
+  }
+};
+
+/**
+ * PATCH /api/user-notifications/:id/read
+ * Mark a single notification as read.
+ */
+exports.markOneRead = async (req, res) => {
+  try {
+    const userId = req.auth.sub;
+    const notif = await UserNotification.findOneAndUpdate(
+      { _id: req.params.id, userId },
+      { $set: { read: true } },
+      { new: true },
+    );
+    if (!notif) return res.status(404).json({ message: 'Notificación no encontrada' });
+    return res.json(notif);
+  } catch (err) {
+    console.error('[gamification] markOneRead error:', err);
+    return res.status(500).json({ message: 'Error al actualizar notificación' });
+  }
+};
+
+/**
+ * DELETE /api/user-notifications/all
+ * Delete all notifications for the authenticated user.
+ */
+exports.deleteAllNotifications = async (req, res) => {
+  try {
+    const userId = req.auth.sub;
+    await UserNotification.deleteMany({ userId });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('[gamification] deleteAllNotifications error:', err);
+    return res.status(500).json({ message: 'Error al borrar notificaciones' });
+  }
+};
+
+/**
+ * DELETE /api/user-notifications/:id
+ * Delete a single notification belonging to the authenticated user.
+ */
+exports.deleteOneNotification = async (req, res) => {
+  try {
+    const userId = req.auth.sub;
+    const notif = await UserNotification.findOneAndDelete({ _id: req.params.id, userId });
+    if (!notif) return res.status(404).json({ message: 'Notificación no encontrada' });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('[gamification] deleteOneNotification error:', err);
+    return res.status(500).json({ message: 'Error al borrar notificación' });
+  }
+};

--- a/src/controllers/leads_controller.js
+++ b/src/controllers/leads_controller.js
@@ -1,0 +1,125 @@
+// src/controllers/leads_controller.js
+// CRUD for landing-page leads ("personas interesadas").
+//   - createLead   : PUBLIC. Called by the bullfit.co landing form.
+//   - listLeads    : admin. Newest first, optional ?status filter.
+//   - updateLead   : admin. Change workflow status.
+//   - deleteLead   : admin. Remove a lead.
+//
+// On a new lead we notify every admin through two channels (best-effort, never
+// blocking the public response): the in-app inbox (UserNotification) and a
+// web-push to their subscribed devices.
+
+const mongoose = require('mongoose');
+const Lead = require('../models/lead');
+const User = require('../models/users');
+const UserNotification = require('../models/userNotification');
+const PushSubscription = require('../models/pushSubscription');
+const { sendPush, isConfigured } = require('../lib/webPush');
+
+const STATUSES = ['nuevo', 'contactado', 'descartado'];
+
+// Fire-and-forget: notify all admins about a new lead.
+async function notifyAdmins(lead) {
+  const admins = await User.find({ role: 'admin' }).select('_id').lean();
+  if (!admins.length) return;
+  const adminIds = admins.map((a) => a._id);
+
+  const fullName = `${lead.nombre} ${lead.apellido}`.trim();
+  const title = '📩 Nuevo interesado';
+  const body = `${fullName} · ${lead.interes || 'sin interés especificado'} — enviado desde la web`;
+  const url = '/';
+
+  // 1) In-app inbox for each admin.
+  await UserNotification.insertMany(
+    adminIds.map((id) => ({ userId: id, title, body, type: 'system', url })),
+  );
+
+  // 2) Best-effort web push to admin devices.
+  if (isConfigured()) {
+    const subs = await PushSubscription.find({ userId: { $in: adminIds } }).lean();
+    if (subs.length) {
+      const payload = { title, body, url };
+      const results = await Promise.all(subs.map((s) => sendPush(s, payload)));
+      const goneIds = subs.filter((_, i) => results[i] && results[i].gone).map((s) => s._id);
+      if (goneIds.length) await PushSubscription.deleteMany({ _id: { $in: goneIds } });
+    }
+  }
+}
+
+exports.createLead = async (req, res) => {
+  const b = req.body || {};
+  const str = (v, max) => (typeof v === 'string' ? v.trim().slice(0, max) : '');
+  const nombre = str(b.nombre, 120);
+  const apellido = str(b.apellido, 120);
+  const whatsapp = str(b.whatsapp, 40);
+  const interes = str(b.interes, 120);
+  const mensaje = str(b.mensaje, 1000);
+  const fuente = str(b.fuente, 60) || 'landing-bullfit';
+
+  if (!nombre || !whatsapp) {
+    return res.status(400).json({ message: 'nombre y whatsapp son requeridos' });
+  }
+
+  const parsedFecha = b.fecha ? new Date(b.fecha) : null;
+  const fecha = parsedFecha && !Number.isNaN(parsedFecha.getTime()) ? parsedFecha : new Date();
+
+  try {
+    const lead = await Lead.create({ nombre, apellido, whatsapp, interes, mensaje, fuente, fecha });
+    // Never block the public response on notification delivery.
+    notifyAdmins(lead).catch((e) => console.error('[leads] notify admins error:', e));
+    return res.status(201).json({ ok: true, id: lead._id });
+  } catch (err) {
+    console.error('[leads] create error:', err);
+    return res.status(500).json({ message: 'Error guardando el interesado' });
+  }
+};
+
+exports.listLeads = async (req, res) => {
+  const { status } = req.query;
+  const filter = {};
+  if (status && STATUSES.includes(status)) filter.status = status;
+  try {
+    const [leads, newCount] = await Promise.all([
+      Lead.find(filter).sort({ createdAt: -1 }).limit(500).lean(),
+      Lead.countDocuments({ status: 'nuevo' }),
+    ]);
+    return res.json({ leads, newCount });
+  } catch (err) {
+    console.error('[leads] list error:', err);
+    return res.status(500).json({ message: 'Error cargando los interesados' });
+  }
+};
+
+exports.updateLead = async (req, res) => {
+  const { id } = req.params;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'id inválido' });
+  }
+  const { status } = req.body || {};
+  if (!STATUSES.includes(status)) {
+    return res.status(400).json({ message: 'status inválido' });
+  }
+  try {
+    const lead = await Lead.findByIdAndUpdate(id, { status }, { new: true }).lean();
+    if (!lead) return res.status(404).json({ message: 'Interesado no encontrado' });
+    return res.json({ lead });
+  } catch (err) {
+    console.error('[leads] update error:', err);
+    return res.status(500).json({ message: 'Error actualizando el interesado' });
+  }
+};
+
+exports.deleteLead = async (req, res) => {
+  const { id } = req.params;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'id inválido' });
+  }
+  try {
+    const deleted = await Lead.findByIdAndDelete(id);
+    if (!deleted) return res.status(404).json({ message: 'Interesado no encontrado' });
+    return res.status(204).end();
+  } catch (err) {
+    console.error('[leads] delete error:', err);
+    return res.status(500).json({ message: 'Error eliminando el interesado' });
+  }
+};

--- a/src/controllers/push_controller.js
+++ b/src/controllers/push_controller.js
@@ -10,6 +10,7 @@
 const mongoose = require('mongoose');
 const PushSubscription = require('../models/pushSubscription');
 const NotificationLog = require('../models/notificationLog');
+const NotificationTemplate = require('../models/notificationTemplate');
 const User = require('../models/users');
 const { sendPush, isConfigured, getPublicKey } = require('../lib/webPush');
 
@@ -231,36 +232,91 @@ exports.listRecipients = async (req, res) => {
 /**
  * GET /api/notifications/templates
  *
- * Returns the most recent unique (title, body) pairs the admin has
- * broadcast, newest first. Used by the composer to one-click reuse a
- * previous message. We deduplicate at query time so an admin who
- * resends the same message ten times still gets one entry. Limit is
- * capped at 50 server-side regardless of what the client asked for.
+ * Returns the admin's saved favorite templates, newest first. These are ONLY
+ * the messages explicitly starred in the composer (NotificationTemplate), not
+ * the full send history. Limit is capped at 50 server-side.
  */
 exports.listTemplates = async (req, res) => {
-  const requestedLimit = Number(req.query.limit) || 10;
+  const requestedLimit = Number(req.query.limit) || 20;
   const limit = Math.max(1, Math.min(50, requestedLimit));
 
   try {
-    const docs = await NotificationLog.aggregate([
-      { $sort: { createdAt: -1 } },
-      {
-        $group: {
-          _id: { title: '$title', body: '$body' },
-          title: { $first: '$title' },
-          body: { $first: '$body' },
-          url: { $first: '$url' },
-          lastSentAt: { $first: '$createdAt' },
-          uses: { $sum: 1 },
-        },
-      },
-      { $sort: { lastSentAt: -1 } },
-      { $limit: limit },
-      { $project: { _id: 0 } },
-    ]);
+    const docs = await NotificationTemplate.find({})
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .select('title body url createdAt')
+      .lean();
     return res.json({ templates: docs });
   } catch (err) {
     console.error('[push/templates] error:', err);
     return res.status(500).json({ message: 'Error cargando plantillas' });
+  }
+};
+
+/**
+ * POST /api/notifications/templates
+ * Body: { title, body, url? }
+ *
+ * Saves a message as a favorite template (the composer's ⭐ button). If a
+ * template with the same (title, body) already exists, that one is returned
+ * instead of creating a duplicate.
+ */
+exports.createTemplate = async (req, res) => {
+  const title = (req.body && typeof req.body.title === 'string') ? req.body.title.trim() : '';
+  const body = (req.body && typeof req.body.body === 'string') ? req.body.body.trim() : '';
+  const url = (req.body && typeof req.body.url === 'string') ? req.body.url.trim() : '/';
+
+  if (!title || !body) {
+    return res.status(400).json({ message: 'title y body son requeridos' });
+  }
+  if (title.length > 80) {
+    return res.status(400).json({ message: 'title no puede exceder 80 caracteres' });
+  }
+  if (body.length > 240) {
+    return res.status(400).json({ message: 'body no puede exceder 240 caracteres' });
+  }
+
+  try {
+    // Idempotent on (title, body): reuse the existing favorite if present.
+    const existing = await NotificationTemplate.findOne({ title, body }).lean();
+    if (existing) {
+      return res.status(200).json({ template: existing, created: false });
+    }
+    const tpl = await NotificationTemplate.create({
+      title,
+      body,
+      url,
+      createdBy: req.auth && req.auth.sub,
+    });
+    return res.status(201).json({ template: tpl, created: true });
+  } catch (err) {
+    // Unique-index race: another request created the same pair first.
+    if (err && err.code === 11000) {
+      const existing = await NotificationTemplate.findOne({ title, body }).lean();
+      return res.status(200).json({ template: existing, created: false });
+    }
+    console.error('[push/templates create] error:', err);
+    return res.status(500).json({ message: 'Error guardando la plantilla' });
+  }
+};
+
+/**
+ * DELETE /api/notifications/templates/:id
+ * Removes a saved favorite template.
+ */
+exports.deleteTemplate = async (req, res) => {
+  const { id } = req.params;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ message: 'id inválido' });
+  }
+  try {
+    const deleted = await NotificationTemplate.findByIdAndDelete(id);
+    if (!deleted) {
+      return res.status(404).json({ message: 'Plantilla no encontrada' });
+    }
+    return res.status(204).end();
+  } catch (err) {
+    console.error('[push/templates delete] error:', err);
+    return res.status(500).json({ message: 'Error eliminando la plantilla' });
   }
 };

--- a/src/controllers/reservations_controllers.js
+++ b/src/controllers/reservations_controllers.js
@@ -3,6 +3,7 @@ const { validationResult } = require('express-validator');
 const axios = require('axios');
 const Reservation = require('../models/reservations');
 const User = require('../models/users');
+const { updateUserStreak } = require('../services/gamificationService');
 const Slot = require('../models/quotaLimits');
 const Counter = require('../models/counter')
 const UserFinance = require('../models/finances');
@@ -368,6 +369,14 @@ exports.updateUserTrainingType = async (req, res) => {
       hour: updatedReservation.hour,
     }));
     queueReservationCacheInvalidation(updatedReservation.userId);
+
+    // Recalculate gamification streak whenever attendance changes.
+    // Fire-and-forget: don't block the response.
+    if (Attendance) {
+      updateUserStreak(updatedReservation.userId.toString()).catch((err) =>
+        console.error('[gamification] streak update failed:', err.message)
+      );
+    }
 
     res.status(200).json(updatedReservation);
   } catch (error) {

--- a/src/controllers/stats_controller.js
+++ b/src/controllers/stats_controller.js
@@ -216,15 +216,24 @@ const getStats = async (req, res) => {
       ]),
     ]);
 
-    // Normalize day-of-week
+    // Normalize day-of-week. The `dayOfWeek` field in the DB is a mess of
+    // English/Spanish, accented/unaccented values ("Wednesday", "Miércoles",
+    // "Miercoles"). We canonicalize by stripping accents + lowercasing so all
+    // variants collapse onto a single bucket. Without this, ~3800 "Miércoles"
+    // reservations fell through and Wednesday looked nearly empty.
     const dayOrder = ['Lunes', 'Martes', 'Miercoles', 'Jueves', 'Viernes', 'Sabado'];
-    const englishMap = {
-      Monday: 'Lunes', Tuesday: 'Martes', Wednesday: 'Miercoles',
-      Thursday: 'Jueves', Friday: 'Viernes', Saturday: 'Sabado',
+    const stripAccents = (s) => s.normalize('NFD').replace(/[̀-ͯ]/g, '');
+    const dayCanonical = {
+      monday: 'Lunes', tuesday: 'Martes', wednesday: 'Miercoles',
+      thursday: 'Jueves', friday: 'Viernes', saturday: 'Sabado', sunday: 'Domingo',
+      lunes: 'Lunes', martes: 'Martes', miercoles: 'Miercoles',
+      jueves: 'Jueves', viernes: 'Viernes', sabado: 'Sabado', domingo: 'Domingo',
     };
     const dayMap = {};
     reservationsByDay.forEach((d) => {
-      const key = englishMap[d._id] || d._id;
+      const raw = (d._id || '').toString().trim();
+      const norm = stripAccents(raw).toLowerCase();
+      const key = dayCanonical[norm] || raw;
       dayMap[key] = (dayMap[key] || 0) + d.count;
     });
 

--- a/src/jobs/inactivityJob.js
+++ b/src/jobs/inactivityJob.js
@@ -1,0 +1,124 @@
+// src/jobs/inactivityJob.js
+// Daily cron job: notify active users who haven't made a reservation in
+// 3 or more business days (Colombian calendar, Mon–Fri excluding holidays).
+//
+// Schedule: runs every weekday at 09:00 Bogotá time.
+//   Cron expression: '0 9 * * 1-5'  (Mon–Fri, 9am)
+//
+// Flow per run:
+//   1. Find all users with Active='Sí'.
+//   2. For each, find their most recent reservation (any status/attendance).
+//   3. If the most recent reservation date is 3+ business days before today,
+//      and we haven't already sent an inactivity alert today:
+//       a. Create a UserNotification record (shows in bell icon).
+//       b. Send a web-push notification to their subscribed devices.
+//   4. Log a summary.
+//
+// Deduplication: we set a `dedupeKey` of 'inactivity-<userId>-<today>' so
+// re-runs (restarts, retries) don't flood the user with duplicates.
+
+const cron = require('node-cron');
+const moment = require('moment-timezone');
+const User = require('../models/users');
+const Reservation = require('../models/reservations');
+const UserNotification = require('../models/userNotification');
+const PushSubscription = require('../models/pushSubscription');
+const { sendPush } = require('../lib/webPush');
+const { businessDaysSince } = require('../utils/colombianHolidays');
+
+const TZ = 'America/Bogota';
+const INACTIVITY_THRESHOLD_DAYS = 3;
+
+async function runInactivityCheck() {
+  const today = moment.tz(TZ).format('YYYY-MM-DD');
+  console.log(`[inactivity-job] Starting check for ${today}`);
+
+  try {
+    // 1. Fetch all active users.
+    const activeUsers = await User.find({ Active: 'Sí' }, { _id: 1, FirstName: 1 }).lean();
+    if (!activeUsers.length) {
+      console.log('[inactivity-job] No active users found. Done.');
+      return;
+    }
+
+    let notified = 0;
+    let skipped = 0;
+
+    for (const user of activeUsers) {
+      const userId = user._id.toString();
+      const dedupeKey = `inactivity-${userId}-${today}`;
+
+      // Skip if already notified today.
+      const alreadySent = await UserNotification.exists({ dedupeKey });
+      if (alreadySent) { skipped++; continue; }
+
+      // Find most recent reservation.
+      const lastReservation = await Reservation.findOne(
+        { userId: user._id },
+        { day: 1 },
+      ).sort({ day: -1 }).lean();
+
+      let daysSince;
+      if (!lastReservation) {
+        // No reservations ever — use registration date or treat as very inactive.
+        daysSince = INACTIVITY_THRESHOLD_DAYS + 1;
+      } else {
+        daysSince = businessDaysSince(lastReservation.day);
+      }
+
+      if (daysSince < INACTIVITY_THRESHOLD_DAYS) { skipped++; continue; }
+
+      // Create notification in the bell inbox.
+      const title = 'Te extrañamos en Bullfit 🔥';
+      const body = `${user.FirstName}, llevas ${daysSince} días sin entrenar. ¡Tu racha te espera!`;
+      const url = `/reservations/${userId}`;
+
+      const notif = await UserNotification.create({
+        userId: user._id,
+        title,
+        body,
+        type: 'inactivity',
+        read: false,
+        url,
+        dedupeKey,
+      });
+
+      // Send web-push to all their subscriptions.
+      const subs = await PushSubscription.find({ userId: user._id }).lean();
+      const pushPayload = { title, body, url };
+
+      for (const sub of subs) {
+        const result = await sendPush(sub, pushPayload);
+        if (result.gone) {
+          // Clean up dead subscription.
+          await PushSubscription.deleteOne({ _id: sub._id });
+        }
+      }
+
+      // Mark push as sent on the notification record.
+      if (subs.length) {
+        await UserNotification.updateOne({ _id: notif._id }, { $set: { pushSent: true } });
+      }
+
+      notified++;
+    }
+
+    console.log(`[inactivity-job] Done. Notified: ${notified}, Skipped: ${skipped}`);
+  } catch (err) {
+    console.error('[inactivity-job] Error during check:', err);
+  }
+}
+
+/**
+ * Start the scheduled inactivity job.
+ * Call this once from app.js after the DB connection is open.
+ */
+function startInactivityJob() {
+  // Run at 09:00 Bogotá time, Mon–Fri.
+  cron.schedule('0 9 * * 1-5', runInactivityCheck, {
+    timezone: TZ,
+  });
+  console.log('[inactivity-job] Scheduled: weekdays at 09:00 Bogotá');
+}
+
+module.exports = { startInactivityJob, runInactivityCheck };

--- a/src/models/lead.js
+++ b/src/models/lead.js
@@ -1,0 +1,30 @@
+// src/models/lead.js
+// "Persona interesada" submitted from the public landing page (bullfit.co).
+// Created by an unauthenticated POST /api/leads; read/managed by admins.
+
+const mongoose = require('mongoose');
+
+const leadSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true, trim: true, maxlength: 120 },
+    apellido: { type: String, trim: true, default: '', maxlength: 120 },
+    whatsapp: { type: String, required: true, trim: true, maxlength: 40 },
+    interes: { type: String, trim: true, default: '', maxlength: 120 },
+    mensaje: { type: String, trim: true, default: '', maxlength: 1000 },
+    fuente: { type: String, trim: true, default: 'landing-bullfit', maxlength: 60 },
+    // Submission timestamp as reported by the landing (falls back to now).
+    fecha: { type: Date, default: () => new Date() },
+    // Admin workflow status.
+    status: {
+      type: String,
+      enum: ['nuevo', 'contactado', 'descartado'],
+      default: 'nuevo',
+      index: true,
+    },
+  },
+  { timestamps: true },
+);
+
+leadSchema.index({ createdAt: -1 });
+
+module.exports = mongoose.model('Lead', leadSchema);

--- a/src/models/notificationTemplate.js
+++ b/src/models/notificationTemplate.js
@@ -1,0 +1,24 @@
+// src/models/notificationTemplate.js
+// A favorite/saved notification template. Unlike the history-derived feed
+// (NotificationLog), these are ONLY the messages an admin explicitly starred
+// in the composer. The composer's "Reutilizar plantilla" dropdown reads from
+// this collection, and admins can delete entries one by one.
+
+const mongoose = require('mongoose');
+
+const notificationTemplateSchema = new mongoose.Schema(
+  {
+    title: { type: String, required: true, trim: true, maxlength: 80 },
+    body: { type: String, required: true, trim: true, maxlength: 240 },
+    url: { type: String, default: '/' },
+    createdBy: { type: mongoose.Schema.Types.ObjectId, ref: 'User', index: true },
+  },
+  { timestamps: true },
+);
+
+// Avoid duplicate favorites for the same (title, body) pair.
+notificationTemplateSchema.index({ title: 1, body: 1 }, { unique: true });
+// Frequent query: newest favorites first.
+notificationTemplateSchema.index({ createdAt: -1 });
+
+module.exports = mongoose.model('NotificationTemplate', notificationTemplateSchema);

--- a/src/models/userNotification.js
+++ b/src/models/userNotification.js
@@ -1,0 +1,44 @@
+// src/models/userNotification.js
+// Per-user notification inbox. Each document is one notification delivered
+// (or queued for delivery) to a specific user.
+//
+// Types:
+//   'inactivity'  - user hasn't reserved in 3+ business days
+//   'streak'      - streak milestone reached (weekly)
+//   'achievement' - badge/logro unlocked
+//   'system'      - admin-sent or generic message
+//
+// The 'read' field drives the unread-badge count in the bell icon.
+// The 'pushSent' field avoids sending duplicate web-push for the same notification.
+
+const mongoose = require('mongoose');
+
+const userNotificationSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    title: { type: String, required: true, trim: true },
+    body: { type: String, required: true, trim: true },
+    type: {
+      type: String,
+      enum: ['inactivity', 'streak', 'achievement', 'system'],
+      default: 'system',
+    },
+    read: { type: Boolean, default: false },
+    url: { type: String, default: '/' },
+    pushSent: { type: Boolean, default: false },
+    // Deduplication key — prevents sending the same inactivity alert twice
+    // on the same calendar day. Format: '<type>-<userId>-<YYYY-MM-DD>'.
+    dedupeKey: { type: String, index: true, sparse: true },
+  },
+  { timestamps: true },
+);
+
+// Fetch unread first, then newest first.
+userNotificationSchema.index({ userId: 1, read: 1, createdAt: -1 });
+
+module.exports = mongoose.model('UserNotification', userNotificationSchema);

--- a/src/models/userStreak.js
+++ b/src/models/userStreak.js
@@ -1,0 +1,37 @@
+// src/models/userStreak.js
+// Stores the computed streak state for each user.
+// Updated every time an admin marks Attendance='Si' or 'No'.
+//
+// A "streak week" = Mon-Fri window where the user attended at least 3 days.
+// Weekends and Colombian public holidays don't count.
+//
+// Fields:
+//   currentStreak     - consecutive completed weeks up to and including today
+//   longestStreak     - all-time highest currentStreak value
+//   totalActivities   - total attended sessions within the current streak run
+//   streakStartDate   - YYYY-MM-DD of the Monday that started the current streak
+//   lastAttendedDate  - YYYY-MM-DD of the most recent Attendance='Si' session
+//   lastComputedAt    - when we last recalculated (used by cron to avoid re-work)
+
+const mongoose = require('mongoose');
+
+const userStreakSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      unique: true,
+      index: true,
+    },
+    currentStreak: { type: Number, default: 0 },
+    longestStreak: { type: Number, default: 0 },
+    totalActivities: { type: Number, default: 0 }, // sessions in current streak
+    streakStartDate: { type: String, default: null }, // YYYY-MM-DD
+    lastAttendedDate: { type: String, default: null }, // YYYY-MM-DD
+    lastComputedAt: { type: Date, default: null },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model('UserStreak', userStreakSchema);

--- a/src/routes/api/gamification_routes.js
+++ b/src/routes/api/gamification_routes.js
@@ -1,0 +1,39 @@
+// src/routes/api/gamification_routes.js
+// Gamification + notification-bell routes.
+//
+// Auth:
+//   - Streak/calendar endpoints: requireAuth (any logged-in user for their own
+//     data; admin can query any userId via requireAdmin guard in controller).
+//   - Notification endpoints: requireAuth (each controller filters by req.auth.sub).
+
+const express = require('express');
+const router = express.Router();
+const ctrl = require('../../controllers/gamification_controller');
+const { requireAuth } = require('../../middleware/auth');
+
+// ── Streak + calendar ────────────────────────────────────────────────────────
+// GET /api/gamification/:userId?year=2026&month=6
+router.get('/gamification/:userId', requireAuth, ctrl.getUserGamification);
+
+// GET /api/gamification/:userId/streak  (lightweight, for customer list cards)
+router.get('/gamification/:userId/streak', requireAuth, ctrl.getUserStreak);
+
+// ── Notification bell ────────────────────────────────────────────────────────
+// Order matters: put /read-all and /all before /:id to avoid route shadowing.
+
+// GET /api/user-notifications
+router.get('/user-notifications', requireAuth, ctrl.listNotifications);
+
+// PATCH /api/user-notifications/read-all
+router.patch('/user-notifications/read-all', requireAuth, ctrl.markAllRead);
+
+// PATCH /api/user-notifications/:id/read
+router.patch('/user-notifications/:id/read', requireAuth, ctrl.markOneRead);
+
+// DELETE /api/user-notifications/all
+router.delete('/user-notifications/all', requireAuth, ctrl.deleteAllNotifications);
+
+// DELETE /api/user-notifications/:id
+router.delete('/user-notifications/:id', requireAuth, ctrl.deleteOneNotification);
+
+module.exports = router;

--- a/src/routes/api/leads_routes.js
+++ b/src/routes/api/leads_routes.js
@@ -1,0 +1,19 @@
+// src/routes/api/leads_routes.js
+// Landing-page leads ("personas interesadas").
+//   POST   /api/leads        - PUBLIC (the bullfit.co landing form)
+//   GET    /api/leads        - admin, list (optional ?status=)
+//   PATCH  /api/leads/:id     - admin, change status
+//   DELETE /api/leads/:id     - admin, remove
+
+const express = require('express');
+
+const router = express.Router();
+const ctrl = require('../../controllers/leads_controller');
+const { requireAdmin } = require('../../middleware/auth');
+
+router.post('/leads', ctrl.createLead);
+router.get('/leads', requireAdmin, ctrl.listLeads);
+router.patch('/leads/:id', requireAdmin, ctrl.updateLead);
+router.delete('/leads/:id', requireAdmin, ctrl.deleteLead);
+
+module.exports = router;

--- a/src/routes/api/push_routes.js
+++ b/src/routes/api/push_routes.js
@@ -23,6 +23,8 @@ router.post('/push/unsubscribe', requireAuth, pushController.unsubscribe);
 // Admin-only.
 router.post('/notifications', requireAdmin, pushController.sendBroadcast);
 router.get('/notifications/templates', requireAdmin, pushController.listTemplates);
+router.post('/notifications/templates', requireAdmin, pushController.createTemplate);
+router.delete('/notifications/templates/:id', requireAdmin, pushController.deleteTemplate);
 router.get('/notifications/recipients', requireAdmin, pushController.listRecipients);
 
 module.exports = router;

--- a/src/services/gamificationService.js
+++ b/src/services/gamificationService.js
@@ -1,0 +1,310 @@
+// src/services/gamificationService.js
+// Core streak + calendar logic for the Bullfit gamification system.
+//
+// STREAK DEFINITION
+//   A "week" runs Monday through Friday (Colombian business days only).
+//   A week is COMPLETE if the user attended (Attendance='Si') at least 3
+//   different business days in that Mon-Fri window.
+//   The streak = number of consecutive COMPLETE weeks ending at the most
+//   recent fully-elapsed week or the current in-progress week (counted
+//   if it already has 3+ days regardless of whether it's finished).
+//
+// CALENDAR DATA
+//   For the profile calendar view, we return one or more months worth of
+//   days annotated with attendance status, grouped by ISO week.
+
+const moment = require('moment-timezone');
+const Reservation = require('../models/reservations');
+const UserStreak = require('../models/userStreak');
+const { isBusinessDay } = require('../utils/colombianHolidays');
+
+const TZ = 'America/Bogota';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Monday of the ISO week that contains `dateStr`. */
+function weekStart(dateStr) {
+  return moment.tz(dateStr, TZ).startOf('isoWeek').format('YYYY-MM-DD');
+}
+
+/** Friday of the ISO week that contains `dateStr`. */
+function weekEnd(dateStr) {
+  return moment.tz(dateStr, TZ).startOf('isoWeek').add(4, 'days').format('YYYY-MM-DD');
+}
+
+/** Key for grouping: 'YYYY-[W]WW' (ISO week string). */
+function weekKey(dateStr) {
+  return moment.tz(dateStr, TZ).format('GGGG-[W]WW');
+}
+
+// ─── Core Streak Calculator ──────────────────────────────────────────────────
+
+/**
+ * Compute streak data for a user from their attendance history.
+ *
+ * @param {string} userId  - Mongoose ObjectId string
+ * @returns {Object} { currentStreak, longestStreak, totalActivities,
+ *                     streakStartDate, lastAttendedDate }
+ */
+async function computeStreak(userId) {
+  // Fetch ALL attended reservations, oldest first.
+  const attended = await Reservation.find(
+    { userId, Attendance: 'Si' },
+    { day: 1, _id: 0 },
+  ).sort({ day: 1 }).lean();
+
+  if (!attended.length) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      totalActivities: 0,
+      streakStartDate: null,
+      lastAttendedDate: null,
+    };
+  }
+
+  // Group attended days by ISO week key, counting only distinct business days.
+  const weekMap = {}; // weekKey → Set of day strings
+  for (const r of attended) {
+    if (!isBusinessDay(r.day)) continue; // skip if somehow on a holiday/weekend
+    const k = weekKey(r.day);
+    if (!weekMap[k]) weekMap[k] = new Set();
+    weekMap[k].add(r.day);
+  }
+
+  // Sort weeks chronologically.
+  const sortedWeeks = Object.keys(weekMap).sort();
+  if (!sortedWeeks.length) {
+    return {
+      currentStreak: 0,
+      longestStreak: 0,
+      totalActivities: 0,
+      streakStartDate: null,
+      lastAttendedDate: null,
+    };
+  }
+
+  const MIN_DAYS = 3; // days required per week to count as "complete"
+
+  const todayKey = weekKey(moment.tz(TZ).format('YYYY-MM-DD'));
+
+  // Build list of { key, complete, start, days } for each week that has attendance.
+  const weekList = sortedWeeks.map((k) => ({
+    key: k,
+    days: weekMap[k].size,
+    complete: weekMap[k].size >= MIN_DAYS,
+    start: moment.tz(k, 'GGGG-[W]WW', TZ).startOf('isoWeek').format('YYYY-MM-DD'),
+  }));
+
+  // Walk the sorted week list and find consecutive complete-week runs.
+  // We consider two weeks "consecutive" if no complete intermediate week
+  // was skipped. If a week was entirely skipped (no attendance at all) and
+  // was in the past, the streak resets — UNLESS we decide to be lenient.
+  // For Bullfit we use STRICT consecutive: any gap week (past, fully elapsed,
+  // no attendance or < 3 days) resets the counter.
+
+  let best = 0;
+  let bestStart = null;
+  let run = 0;
+  let runStart = null;
+  let prevKey = null;
+
+  // Helper: week keys between two keys (exclusive, to detect gaps).
+  function weeksBetween(keyA, keyB) {
+    let cur = moment.tz(keyA, 'GGGG-[W]WW', TZ).add(1, 'week');
+    const end = moment.tz(keyB, 'GGGG-[W]WW', TZ);
+    const gaps = [];
+    while (cur.isBefore(end)) {
+      gaps.push(cur.format('GGGG-[W]WW'));
+      cur.add(1, 'week');
+    }
+    return gaps;
+  }
+
+  for (const w of weekList) {
+    const isCurrentOrFuture = w.key >= todayKey;
+    const gapWeeks = prevKey ? weeksBetween(prevKey, w.key) : [];
+    const hasGap = gapWeeks.length > 0;
+
+    if (hasGap || (!w.complete && !isCurrentOrFuture)) {
+      // Streak resets.
+      if (run > best) { best = run; bestStart = runStart; }
+      run = w.complete ? 1 : 0;
+      runStart = w.complete ? w.start : null;
+    } else if (w.complete) {
+      run++;
+      if (!runStart) runStart = w.start;
+    }
+    // Incomplete current week: don't reset — user still has days to attend.
+    prevKey = w.key;
+  }
+  if (run > best) { best = run; bestStart = runStart; }
+
+  // Current streak = last run value (if the last week was complete or is current).
+  const lastWeek = weekList[weekList.length - 1];
+  let currentStreak = 0;
+  let currentStreakStart = null;
+
+  if (lastWeek.complete || lastWeek.key >= todayKey) {
+    // Re-walk to get the final consecutive run from the end.
+    let cur2 = 0;
+    let cur2Start = null;
+    let prev2 = null;
+    for (const w of weekList) {
+      const isCurrentOrFuture2 = w.key >= todayKey;
+      const gap2 = prev2 ? weeksBetween(prev2, w.key).length > 0 : false;
+      if (gap2 || (!w.complete && !isCurrentOrFuture2)) {
+        cur2 = w.complete ? 1 : 0;
+        cur2Start = w.complete ? w.start : null;
+      } else if (w.complete) {
+        cur2++;
+        if (!cur2Start) cur2Start = w.start;
+      }
+      prev2 = w.key;
+    }
+    currentStreak = cur2;
+    currentStreakStart = cur2Start;
+  }
+
+  // Total activities in the current streak period.
+  let totalActivities = 0;
+  if (currentStreakStart) {
+    totalActivities = attended.filter((r) => r.day >= currentStreakStart).length;
+  }
+
+  const longestStreak = Math.max(best, currentStreak);
+  const lastAttendedDate = attended[attended.length - 1].day;
+
+  return {
+    currentStreak,
+    longestStreak,
+    totalActivities,
+    streakStartDate: currentStreakStart,
+    lastAttendedDate,
+  };
+}
+
+// ─── Streak Updater ──────────────────────────────────────────────────────────
+
+/**
+ * Recompute and persist streak data for `userId` in UserStreak.
+ * Called after every attendance update.
+ */
+async function updateUserStreak(userId) {
+  const data = await computeStreak(userId);
+  const streakDoc = await UserStreak.findOneAndUpdate(
+    { userId },
+    {
+      $set: {
+        ...data,
+        lastComputedAt: new Date(),
+      },
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true },
+  );
+  return streakDoc;
+}
+
+// ─── Calendar Builder ────────────────────────────────────────────────────────
+
+/**
+ * Build calendar data for a user for a given month.
+ * Returns an array of week rows, each containing day annotations.
+ *
+ * @param {string} userId
+ * @param {number} year   - e.g. 2026
+ * @param {number} month  - 1-based (1=Jan)
+ * @returns {Object} { year, month, weeks: [{ weekNum, days: [...], daysAttended, complete }] }
+ */
+async function buildCalendarMonth(userId, year, month) {
+  const monthStr = String(month).padStart(2, '0');
+  const startOfMonth = `${year}-${monthStr}-01`;
+  const endOfMonth = moment.tz(startOfMonth, TZ).endOf('month').format('YYYY-MM-DD');
+
+  // Fetch reservations for this user in this month.
+  const reservations = await Reservation.find(
+    { userId, day: { $gte: startOfMonth, $lte: endOfMonth } },
+    { day: 1, Attendance: 1, TrainingType: 1, _id: 0 },
+  ).lean();
+
+  // Build lookup: day → { attended, trainingType }
+  const dayMap = {};
+  for (const r of reservations) {
+    // If multiple reservations same day, prefer 'Si'
+    if (!dayMap[r.day] || r.Attendance === 'Si') {
+      dayMap[r.day] = {
+        attended: r.Attendance === 'Si',
+        hasReservation: true,
+        trainingType: r.TrainingType || null,
+      };
+    }
+  }
+
+  // Build all days of the month.
+  const days = [];
+  let cur = moment.tz(startOfMonth, TZ);
+  const end = moment.tz(endOfMonth, TZ);
+  while (cur.isSameOrBefore(end, 'day')) {
+    const d = cur.format('YYYY-MM-DD');
+    const dow = cur.isoWeekday(); // 1=Mon, 7=Sun
+    const isBiz = isBusinessDay(d);
+    days.push({
+      date: d,
+      day: cur.date(),
+      dayOfWeek: dow,
+      isWeekend: dow >= 6,
+      isBusinessDay: isBiz,
+      ...(dayMap[d] || { attended: false, hasReservation: false, trainingType: null }),
+    });
+    cur.add(1, 'day');
+  }
+
+  // Group days into ISO weeks (Mon–Sun), include padding from prev/next months.
+  const firstDay = moment.tz(startOfMonth, TZ);
+  const lastDay = moment.tz(endOfMonth, TZ);
+
+  // Pad start to Monday of first week.
+  let weekStart2 = firstDay.clone().startOf('isoWeek');
+  // Pad end to Sunday of last week.
+  let weekEnd2 = lastDay.clone().endOf('isoWeek');
+
+  const allDays = [];
+  let c = weekStart2.clone();
+  while (c.isSameOrBefore(weekEnd2, 'day')) {
+    const d = c.format('YYYY-MM-DD');
+    const isInMonth = c.month() === firstDay.month();
+    const dow = c.isoWeekday();
+    const isBiz = isBusinessDay(d);
+    if (isInMonth) {
+      // Use the annotation we already computed.
+      const existing = days.find((x) => x.date === d);
+      allDays.push(existing || { date: d, day: c.date(), dayOfWeek: dow, isWeekend: dow >= 6, isBusinessDay: isBiz, attended: false, hasReservation: false, trainingType: null, isInMonth: true });
+    } else {
+      allDays.push({ date: d, day: c.date(), dayOfWeek: dow, isWeekend: dow >= 6, isBusinessDay: isBiz, attended: false, hasReservation: false, trainingType: null, isInMonth: false });
+    }
+    if (allDays[allDays.length - 1].isInMonth === undefined) allDays[allDays.length - 1].isInMonth = true;
+    c.add(1, 'day');
+  }
+
+  // Split into weeks (7-day chunks starting Monday).
+  const weeks = [];
+  for (let i = 0; i < allDays.length; i += 7) {
+    const weekDays = allDays.slice(i, i + 7);
+    const bizDays = weekDays.filter((d) => d.isBusinessDay && d.isInMonth !== false);
+    const daysAttended = bizDays.filter((d) => d.attended).length;
+    weeks.push({
+      weekKey: weekKey(weekDays[0].date),
+      days: weekDays,
+      daysAttended,
+      complete: daysAttended >= 3,
+    });
+  }
+
+  return { year: Number(year), month: Number(month), weeks };
+}
+
+module.exports = {
+  computeStreak,
+  updateUserStreak,
+  buildCalendarMonth,
+};

--- a/src/utils/colombianHolidays.js
+++ b/src/utils/colombianHolidays.js
@@ -1,0 +1,159 @@
+// src/utils/colombianHolidays.js
+// Colombian public holidays (festivos) for 2024-2028.
+//
+// Colombia has two types of holidays (Ley 51/1983 and Ley Emiliani/1983):
+//   - Fixed: same calendar date every year.
+//   - Movable (Emiliani): if not on Monday, moved to the next Monday.
+//
+// Movable holidays that apply Emiliani:
+//   Epiphany (Jan 6), Saint Joseph (Mar 19), Peter & Paul (Jun 29),
+//   Columbus Day (Oct 12), All Saints (Nov 1), Cartagena Independence (Nov 11).
+//
+// Easter-dependent movable holidays (do NOT apply Emiliani — exact date):
+//   Holy Thursday (-3d), Good Friday (-2d), Ascension (+39d),
+//   Corpus Christi (+60d), Sacred Heart (+68d).
+//
+// Exported API:
+//   isColombianHoliday(dateString) → Boolean
+//   isBusinessDay(dateString)      → Boolean  (Mon–Fri, not holiday)
+//   countBusinessDays(startStr, endStr) → Number  (inclusive)
+//   addBusinessDays(dateString, n) → 'YYYY-MM-DD'  (n business days later)
+
+const moment = require('moment-timezone');
+
+// ─── Easter (Anonymous Gregorian algorithm) ──────────────────────────────────
+function easterDate(year) {
+  const a = year % 19;
+  const b = Math.floor(year / 100);
+  const c = year % 100;
+  const d = Math.floor(b / 4);
+  const e = b % 4;
+  const f = Math.floor((b + 8) / 25);
+  const g = Math.floor((b - f + 1) / 3);
+  const h = (19 * a + b - d - g + 15) % 30;
+  const i = Math.floor(c / 4);
+  const k = c % 4;
+  const l = (32 + 2 * e + 2 * i - h - k) % 7;
+  const m = Math.floor((a + 11 * h + 22 * l) / 451);
+  const month = Math.floor((h + l - 7 * m + 114) / 31); // 1-based
+  const day = ((h + l - 7 * m + 114) % 31) + 1;
+  return moment.tz({ year, month: month - 1, date: day }, 'America/Bogota');
+}
+
+// Move to the following Monday if not already Monday (Ley Emiliani).
+function nextMonday(m) {
+  const dow = m.isoWeekday(); // 1=Mon … 7=Sun
+  if (dow === 1) return m.clone();
+  return m.clone().add(8 - dow, 'days');
+}
+
+// Format moment as YYYY-MM-DD string.
+function fmt(m) {
+  return m.format('YYYY-MM-DD');
+}
+
+// ─── Holiday set builder for a given year ────────────────────────────────────
+function buildHolidaysForYear(year) {
+  const y = Number(year);
+  const holidays = new Set();
+
+  // — Fixed holidays —
+  holidays.add(`${y}-01-01`); // New Year
+  holidays.add(`${y}-05-01`); // Labor Day
+  holidays.add(`${y}-07-20`); // Independence Day
+  holidays.add(`${y}-08-07`); // Battle of Boyacá
+  holidays.add(`${y}-12-08`); // Immaculate Conception
+  holidays.add(`${y}-12-25`); // Christmas
+
+  // — Emiliani (movable to next Monday) —
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-01-06`, 'America/Bogota')))); // Epiphany
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-03-19`, 'America/Bogota')))); // Saint Joseph
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-06-29`, 'America/Bogota')))); // Peter & Paul
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-10-12`, 'America/Bogota')))); // Columbus Day
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-11-01`, 'America/Bogota')))); // All Saints
+  holidays.add(fmt(nextMonday(moment.tz(`${y}-11-11`, 'America/Bogota')))); // Cartagena Independence
+
+  // — Easter-dependent (exact dates, no Emiliani) —
+  const easter = easterDate(y);
+  holidays.add(fmt(easter.clone().subtract(3, 'days'))); // Holy Thursday
+  holidays.add(fmt(easter.clone().subtract(2, 'days'))); // Good Friday
+  holidays.add(fmt(easter.clone().add(39, 'days')));     // Ascension
+  holidays.add(fmt(easter.clone().add(60, 'days')));     // Corpus Christi
+  holidays.add(fmt(easter.clone().add(68, 'days')));     // Sacred Heart
+
+  return holidays;
+}
+
+// Cache per year so we don't recalculate on every call.
+const _cache = {};
+
+function getHolidaysForYear(year) {
+  if (!_cache[year]) _cache[year] = buildHolidaysForYear(year);
+  return _cache[year];
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * Returns true if `dateStr` (YYYY-MM-DD) is a Colombian public holiday.
+ */
+function isColombianHoliday(dateStr) {
+  const year = dateStr.slice(0, 4);
+  return getHolidaysForYear(year).has(dateStr);
+}
+
+/**
+ * Returns true if `dateStr` is a business day (Mon–Fri, not a holiday).
+ */
+function isBusinessDay(dateStr) {
+  const dow = moment.tz(dateStr, 'America/Bogota').isoWeekday(); // 1=Mon, 7=Sun
+  if (dow === 6 || dow === 7) return false;
+  return !isColombianHoliday(dateStr);
+}
+
+/**
+ * Count business days between startStr and endStr (both inclusive, YYYY-MM-DD).
+ */
+function countBusinessDays(startStr, endStr) {
+  let current = moment.tz(startStr, 'America/Bogota');
+  const end = moment.tz(endStr, 'America/Bogota');
+  let count = 0;
+  while (current.isSameOrBefore(end, 'day')) {
+    if (isBusinessDay(current.format('YYYY-MM-DD'))) count++;
+    current.add(1, 'day');
+  }
+  return count;
+}
+
+/**
+ * Returns the date that is `n` business days after (or before if n<0) `dateStr`.
+ * Result is formatted as 'YYYY-MM-DD'.
+ */
+function addBusinessDays(dateStr, n) {
+  let current = moment.tz(dateStr, 'America/Bogota');
+  const step = n >= 0 ? 1 : -1;
+  let remaining = Math.abs(n);
+  while (remaining > 0) {
+    current.add(step, 'day');
+    if (isBusinessDay(current.format('YYYY-MM-DD'))) remaining--;
+  }
+  return current.format('YYYY-MM-DD');
+}
+
+/**
+ * Returns the number of business days elapsed since `dateStr` up to today (Colombia).
+ * Returns 0 if dateStr is today or in the future.
+ */
+function businessDaysSince(dateStr) {
+  const today = moment.tz('America/Bogota').format('YYYY-MM-DD');
+  if (dateStr >= today) return 0;
+  return countBusinessDays(dateStr, today) - 1; // exclude the start date itself
+}
+
+module.exports = {
+  isColombianHoliday,
+  isBusinessDay,
+  countBusinessDays,
+  addBusinessDays,
+  businessDaysSince,
+};


### PR DESCRIPTION
- Notifications: favorite templates collection (create/list/delete) so only starred messages are saved, not the full send history
- Stats: accent/language-insensitive day-of-week normalization (fixes Wednesday under-count from mixed "Miércoles"/"Wednesday" data)
- CORS: allow https://app.bullfit.co alongside existing origins; CORS_ORIGINS is now additive instead of replacing the built-in allow list
- Includes gamification (streaks) + push notification backend