### PR TITLE
feat(notifications): live agenda SSE + payment 

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,7 +22,9 @@ const pushRoutes = require('./src/routes/api/push_routes');
 const statsRoutes = require('./src/routes/api/stats_routes');
 const gamificationRoutes = require('./src/routes/api/gamification_routes');
 const leadsRoutes = require('./src/routes/api/leads_routes');
+const eventsRoutes = require('./src/routes/api/events_routes');
 const { startInactivityJob } = require('./src/jobs/inactivityJob');
+const { startMembershipExpiryJob } = require('./src/jobs/membershipExpiryJob');
 
 dotenv.config();
 
@@ -72,6 +74,7 @@ db.on('reconnected', () => console.log('MongoDB reconnected'));
 db.once('open', () => {
   console.log('Conexión a la base de datos exitosa');
   startInactivityJob();
+  startMembershipExpiryJob();
 });
 
 
@@ -164,6 +167,10 @@ app.use('/api', authRoutes);
 // Leads BEFORE the routers that apply router-level requireAuth, so the public
 // POST /api/leads (landing form) isn't swallowed by their global guard.
 app.use('/api', leadsRoutes);
+// SSE stream for live reservation updates. Has its own query-token auth (the
+// browser EventSource can't send the Authorization header), so it must NOT sit
+// behind the header-based requireAuth of the reservations router.
+app.use('/api', eventsRoutes);
 // Stats route before authenticated routers (has its own password gate in frontend).
 app.use('/api', statsRoutes);
 app.use('/api', pushRoutes);

--- a/src/controllers/finances_controllers.js
+++ b/src/controllers/finances_controllers.js
@@ -1,7 +1,9 @@
 const moment = require('moment');
 const UserFinance = require('../models/finances');
+const User = require('../models/users');
 const { getPriceValue } = require('../services/priceService');
 const { recomputeDailyFinanceFields } = require('../services/financeService');
+const { notifyUser } = require('../lib/notifyUser');
 
 const syncDailyFinanceRecord = async (finance) => {
   if ((finance.Plan || '').toLowerCase() !== 'diario') {
@@ -188,6 +190,26 @@ exports.updateFinanceById = async (req, res) => {
       { $set: normalizedUpdateData },
       { new: true }
     );
+
+    // Notify the user only when the admin flips this payment to confirmed
+    // (No -> Si). Avoids re-notifying on unrelated edits or repeated saves.
+    const wasConfirmed = currentFinance.reservationPaymentStatus === 'Si';
+    const nowConfirmed = normalizedUpdateData.reservationPaymentStatus === 'Si';
+    if (nowConfirmed && !wasConfirmed) {
+      // Look up the user's name, then notify (fire-and-forget so the response
+      // isn't delayed by the extra read + push).
+      (async () => {
+        const user = await User.findById(currentFinance.userId).select('FirstName').lean();
+        const name = (user && user.FirstName) ? user.FirstName : '';
+        const greeting = name ? ` ${name}` : '';
+        await notifyUser(currentFinance.userId, {
+          title: 'Pago confirmado ✅',
+          body: `Muchas gracias${greeting} 💪 Recibimos tu pago de mensualidad. Ya estás al día — ahora a entrenar sin excusas. ¡Te esperamos en Bullfit!`,
+          url: '/',
+          type: 'system',
+        });
+      })().catch((err) => console.error('[finances] notifyUser failed:', err.message));
+    }
 
     res.json(updatedFinance);
   } catch (error) {

--- a/src/controllers/reservations_controllers.js
+++ b/src/controllers/reservations_controllers.js
@@ -10,6 +10,7 @@ const UserFinance = require('../models/finances');
 const { getPriceValue } = require('../services/priceService');
 const { recomputeDailyFinanceFields, applyDailyFinanceFields } = require('../services/financeService');
 const { getCacheJSON, setCacheJSON, deleteCacheKeys } = require('../lib/cacheUtils');
+const { emitReservationEvent } = require('../lib/reservationEvents');
 const Invitado = require('../models/invitados');
 const mongoose = require('mongoose');
 const moment = require('moment');
@@ -378,6 +379,9 @@ exports.updateUserTrainingType = async (req, res) => {
       );
     }
 
+    // Notify open admin agendas (SSE) so they refresh live. Fire-and-forget.
+    emitReservationEvent({ type: 'updated', reservation: updatedReservation });
+
     res.status(200).json(updatedReservation);
   } catch (error) {
     console.error(error);
@@ -627,6 +631,9 @@ exports.createReservation = async (req, res) => {
     await addReservationToCache(cacheEntry);
     queueReservationCacheInvalidation(userId);
 
+    // Notify open admin agendas (SSE) so they refresh live. Fire-and-forget.
+    emitReservationEvent({ type: 'created', reservation: savedReservation });
+
     // Éxito
     return res.status(201).json(savedReservation);
 
@@ -859,6 +866,9 @@ exports.deleteReservation = async (req, res) => {
 
     await removeReservationCacheEntry(reservationId);
     queueReservationCacheInvalidation(deletedReservation.userId);
+
+    // Notify open admin agendas (SSE) so they refresh live. Fire-and-forget.
+    emitReservationEvent({ type: 'deleted', reservation: deletedReservation });
 
     res.status(200).json(response);
   } catch (error) {

--- a/src/controllers/store_controller.js
+++ b/src/controllers/store_controller.js
@@ -2,6 +2,17 @@ const UserStore = require('../models/store');
 const User = require('../models/users');
 const moment = require('moment-timezone');
 const { getPriceValue } = require('../services/priceService');
+const { notifyUser } = require('../lib/notifyUser');
+
+// Store items are stored as English keys; show their Spanish name in the
+// notification. Same mapping the frontend uses (Statistics.jsx ITEM_LABELS).
+const ITEM_LABELS_ES = {
+  waters: 'Aguas',
+  PreWorkouts: 'Preentrenos',
+  proteins: 'Proteínas',
+  guestPass: 'Invitado',
+};
+const itemLabelEs = (item) => ITEM_LABELS_ES[item] || item || 'tu compra';
 
 
 exports.createStoreConsumption = async (req, res) => {
@@ -51,11 +62,15 @@ exports.updateStoreConsumption = async (req, res) => {
 
   try {
     let finalValue = value;
+    const isGuestPass = typeof item === 'string' && item.toLowerCase() === 'guestpass';
 
-    if (typeof item === 'string' && item.toLowerCase() === 'guestpass') {
+    if (isGuestPass) {
       const guestPrice = await getPriceValue({ item: 'guestPass' });
       finalValue = guestPrice * (Number(quantity) || 0);
     }
+
+    // Read the previous status so we only notify on the No -> Si transition.
+    const previous = await UserStore.findById(consumptionId).select('paymentStatus userId').lean();
 
     const updatedConsumption = await UserStore.findByIdAndUpdate(
       consumptionId,
@@ -65,6 +80,24 @@ exports.updateStoreConsumption = async (req, res) => {
 
     if (!updatedConsumption) {
       return res.status(404).json({ message: 'Consumo de tienda no encontrado' });
+    }
+
+    // Notify the user when the admin confirms the store consumption payment.
+    // Skip guest passes: those belong to a guest profile, not an app user.
+    const wasConfirmed = previous && previous.paymentStatus === 'Si';
+    if (paymentStatus === 'Si' && !wasConfirmed && !isGuestPass && updatedConsumption.userId) {
+      // Look up the user's name, then notify (fire-and-forget).
+      (async () => {
+        const user = await User.findById(updatedConsumption.userId).select('FirstName').lean();
+        const name = (user && user.FirstName) ? user.FirstName : '';
+        const greeting = name ? ` ${name}` : '';
+        await notifyUser(updatedConsumption.userId, {
+          title: 'Pago confirmado ✅',
+          body: `¡Gracias${greeting}! 🙌 Confirmamos el pago de ${itemLabelEs(item)} en la tienda. ¡Te esperamos en Bullfit!`,
+          url: '/',
+          type: 'system',
+        });
+      })().catch((err) => console.error('[store] notifyUser failed:', err.message));
     }
 
     res.json(updatedConsumption);

--- a/src/jobs/membershipExpiryJob.js
+++ b/src/jobs/membershipExpiryJob.js
@@ -1,0 +1,111 @@
+// src/jobs/membershipExpiryJob.js
+// Daily cron job: remind users whose monthly membership (Plan 'Mensual')
+// expires in 2 days, so they renew on time.
+//
+// Schedule: every day at 09:00 Bogotá time. Cron: '0 9 * * *'.
+//
+// Flow per run:
+//   1. Compute target date = today + 2 days (Bogotá), as 'YYYY-MM-DD'.
+//   2. Find Mensual finances whose endDate equals EXACTLY that target.
+//      Matching the exact date is what keeps us on the *current* period:
+//      a stale record from months/years ago has an old endDate and simply
+//      won't match, so we never pick the wrong endDate.
+//   3. Skip the reminder if the user already has a Mensual record with a
+//      later endDate (they already renewed/extended).
+//   4. Notify (bell inbox + web-push) via notifyUser, deduped per period.
+//
+// endDate is stored as 'yyyy-MM-dd' (see finances_controllers.financesUser
+// and the frontend Finances.jsx date pickers).
+
+const cron = require('node-cron');
+const moment = require('moment-timezone');
+const UserFinance = require('../models/finances');
+const User = require('../models/users');
+const UserNotification = require('../models/userNotification');
+const { notifyUser } = require('../lib/notifyUser');
+
+const TZ = 'America/Bogota';
+const DAYS_BEFORE = 2;
+
+const MESES = [
+  'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
+  'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+];
+
+// '2026-06-30' -> '30 de junio'
+const humanizeDate = (isoDate) => {
+  const m = moment.tz(isoDate, 'YYYY-MM-DD', TZ);
+  if (!m.isValid()) return isoDate;
+  return `${m.date()} de ${MESES[m.month()]}`;
+};
+
+async function runMembershipExpiryCheck() {
+  const target = moment.tz(TZ).add(DAYS_BEFORE, 'days').format('YYYY-MM-DD');
+  console.log(`[membership-expiry-job] Checking memberships ending on ${target}`);
+
+  try {
+    // Only the records whose period ends exactly on the target date — this is
+    // always the current/nearest one, never an old endDate.
+    const expiring = await UserFinance.find(
+      { Plan: 'Mensual', endDate: target },
+      { _id: 1, userId: 1, endDate: 1, FirstName: 1 },
+    ).lean();
+
+    if (!expiring.length) {
+      console.log('[membership-expiry-job] No memberships expiring. Done.');
+      return;
+    }
+
+    let notified = 0;
+    let skipped = 0;
+
+    for (const finance of expiring) {
+      if (!finance.userId) { skipped++; continue; }
+
+      const dedupeKey = `membership-expiry-${finance._id}-${target}`;
+
+      // Don't re-notify on job restarts/retries.
+      const alreadySent = await UserNotification.exists({ dedupeKey });
+      if (alreadySent) { skipped++; continue; }
+
+      // If the user already has a membership ending later, they've renewed —
+      // skip the reminder. (String date compare works for 'YYYY-MM-DD'.)
+      const renewed = await UserFinance.exists({
+        userId: finance.userId,
+        Plan: 'Mensual',
+        endDate: { $gt: target },
+      });
+      if (renewed) { skipped++; continue; }
+
+      // Prefer the live user name; fall back to the denormalized finance name.
+      const user = await User.findById(finance.userId).select('FirstName').lean();
+      const name = (user && user.FirstName) || finance.FirstName || '';
+      const greeting = name ? `${name}, ` : '';
+
+      await notifyUser(finance.userId, {
+        title: 'Tu mensualidad está por vencer ⏳',
+        body: `${greeting}tu mensualidad vence el ${humanizeDate(finance.endDate)}. No dejes que nada te detenga — renuévala y mantén el ritmo que traes. ¡En Bullfit te esperamos! 💪`,
+        url: '/',
+        type: 'system',
+        dedupeKey,
+      });
+
+      notified++;
+    }
+
+    console.log(`[membership-expiry-job] Done. Notified: ${notified}, Skipped: ${skipped}`);
+  } catch (err) {
+    console.error('[membership-expiry-job] Error during check:', err);
+  }
+}
+
+/**
+ * Start the scheduled membership-expiry job.
+ * Call once from app.js after the DB connection is open.
+ */
+function startMembershipExpiryJob() {
+  cron.schedule('0 9 * * *', runMembershipExpiryCheck, { timezone: TZ });
+  console.log('[membership-expiry-job] Scheduled: daily at 09:00 Bogotá');
+}
+
+module.exports = { startMembershipExpiryJob, runMembershipExpiryCheck };

--- a/src/lib/notifyUser.js
+++ b/src/lib/notifyUser.js
@@ -1,0 +1,67 @@
+// src/lib/notifyUser.js
+// Single helper to notify ONE user: persists the message to their bell inbox
+// (UserNotification) AND best-effort sends a web-push to all their devices,
+// pruning dead subscriptions. This is the same inbox+push pattern already used
+// in inactivityJob.js and leads_controller.js, factored out so payment-
+// confirmation flows (finances, store) don't re-implement it.
+//
+// Designed to be called fire-and-forget from controllers: it never throws, so
+// a notification failure can't break the request that triggered it.
+
+const UserNotification = require('../models/userNotification');
+const PushSubscription = require('../models/pushSubscription');
+const { sendPush, isConfigured } = require('./webPush');
+
+/**
+ * @param {string|ObjectId} userId  recipient user id
+ * @param {Object} opts
+ * @param {string} opts.title
+ * @param {string} opts.body
+ * @param {string} [opts.url='/']      where the bell click navigates
+ * @param {string} [opts.type='system'] one of the UserNotification enum types
+ * @param {string} [opts.dedupeKey]    optional, prevents duplicate inbox rows
+ * @returns {Promise<Object|null>} the created notification (or null on failure)
+ */
+const notifyUser = async (userId, { title, body, url = '/', type = 'system', dedupeKey } = {}) => {
+  if (!userId || !title || !body) return null;
+
+  // 1) Persist to the bell inbox.
+  let notif = null;
+  try {
+    notif = await UserNotification.create({
+      userId,
+      title,
+      body,
+      type,
+      url,
+      ...(dedupeKey ? { dedupeKey } : {}),
+    });
+  } catch (err) {
+    console.error('[notifyUser] inbox create failed:', err.message);
+  }
+
+  // 2) Best-effort web-push to every registered device.
+  try {
+    if (isConfigured()) {
+      const subs = await PushSubscription.find({ userId }).lean();
+      if (subs.length) {
+        const payload = { title, body, url };
+        const results = await Promise.all(subs.map((s) => sendPush(s, payload)));
+
+        const goneIds = subs.filter((_, i) => results[i] && results[i].gone).map((s) => s._id);
+        if (goneIds.length) {
+          await PushSubscription.deleteMany({ _id: { $in: goneIds } });
+        }
+        if (notif && results.some((r) => r && r.ok)) {
+          await UserNotification.updateOne({ _id: notif._id }, { $set: { pushSent: true } });
+        }
+      }
+    }
+  } catch (err) {
+    console.error('[notifyUser] push failed:', err.message);
+  }
+
+  return notif;
+};
+
+module.exports = { notifyUser };

--- a/src/lib/reservationEvents.js
+++ b/src/lib/reservationEvents.js
@@ -1,0 +1,144 @@
+// src/lib/reservationEvents.js
+// In-process event bus for reservation changes (create / update / delete).
+// The SSE endpoint (routes/api/events_routes.js) subscribes to this bus and
+// streams each event to connected admin clients so the agenda updates live
+// without a page reload.
+//
+// Why an EventEmitter and not just calling the SSE writer directly from the
+// controllers: it decouples the persistence code from the transport. The
+// controllers only "announce" a change; whoever cares (SSE today, maybe push
+// or websockets later) listens. Listeners never throw back into the emitter,
+// so a slow/broken client can't break a reservation write.
+//
+// Multi-instance fan-out (optional): if REDIS_ENABLED === 'true' we ALSO
+// publish each event to a Redis channel and a dedicated subscriber connection
+// re-emits it locally. That way an event produced on instance A reaches SSE
+// clients connected to instance B. Events are tagged with a per-process
+// `origin` id so the subscriber ignores the message it just published itself
+// (no double delivery on the originating instance). If Redis is disabled or
+// unreachable, only the in-process emitter runs — enough for a single
+// instance, which is the current deployment.
+
+const EventEmitter = require('events');
+const Redis = require('ioredis');
+
+const CHANNEL = 'reservations:events';
+const EVENT_NAME = 'reservation';
+
+// Unique id for this process so we can drop our own Redis echo.
+const ORIGIN = `${process.pid}-${Date.now()}`;
+
+const bus = new EventEmitter();
+// Each open SSE connection registers one listener. Lift the default cap (10)
+// so a handful of admins with multiple tabs don't trigger the
+// MaxListenersExceededWarning. 0 = unlimited.
+bus.setMaxListeners(0);
+
+const isRedisEnabled = () => process.env.REDIS_ENABLED === 'true';
+
+// ---- Redis pub/sub (lazy, optional) ---------------------------------------
+let publisher = null;
+let subscriber = null;
+let redisInitTried = false;
+
+const buildRedisOptions = () => ({
+  enableReadyCheck: false,
+  lazyConnect: true,
+  maxRetriesPerRequest: 2,
+});
+
+const makeConnection = () => {
+  const opts = buildRedisOptions();
+  if (process.env.REDIS_URL) {
+    return new Redis(process.env.REDIS_URL, opts);
+  }
+  return new Redis({
+    host: process.env.REDIS_HOST || '127.0.0.1',
+    port: Number(process.env.REDIS_PORT || 6379),
+    password: process.env.REDIS_PASSWORD || undefined,
+    ...opts,
+  });
+};
+
+// Spin up the publisher + subscriber connections once, on first use. A failure
+// here is non-fatal: we log and fall back to in-process-only delivery.
+const ensureRedis = () => {
+  if (!isRedisEnabled() || redisInitTried) return;
+  redisInitTried = true;
+
+  try {
+    publisher = makeConnection();
+    subscriber = makeConnection();
+
+    publisher.on('error', (err) => console.error('[reservationEvents] redis publisher error:', err.message));
+    subscriber.on('error', (err) => console.error('[reservationEvents] redis subscriber error:', err.message));
+
+    subscriber.connect().catch((err) => {
+      console.error('[reservationEvents] redis subscriber connect failed:', err.message);
+    });
+    publisher.connect().catch((err) => {
+      console.error('[reservationEvents] redis publisher connect failed:', err.message);
+    });
+
+    subscriber.subscribe(CHANNEL).catch((err) => {
+      console.error('[reservationEvents] redis subscribe failed:', err.message);
+    });
+
+    subscriber.on('message', (channel, raw) => {
+      if (channel !== CHANNEL) return;
+      try {
+        const message = JSON.parse(raw);
+        // Drop the echo of events we published ourselves; they were already
+        // delivered locally by emitReservationEvent.
+        if (message && message.origin === ORIGIN) return;
+        bus.emit(EVENT_NAME, message.payload);
+      } catch (err) {
+        console.error('[reservationEvents] bad redis message:', err.message);
+      }
+    });
+  } catch (err) {
+    console.error('[reservationEvents] redis init failed:', err.message);
+    publisher = null;
+    subscriber = null;
+  }
+};
+
+/**
+ * Announce a reservation change. Safe to call fire-and-forget from controllers.
+ * @param {Object} input
+ * @param {'created'|'updated'|'deleted'} input.type
+ * @param {Object} input.reservation - the saved/updated/deleted document (lean or mongoose)
+ */
+const emitReservationEvent = ({ type, reservation } = {}) => {
+  try {
+    const r = reservation || {};
+    const payload = {
+      type,
+      reservationId: r._id ? String(r._id) : undefined,
+      userId: r.userId ? String(r.userId) : undefined,
+      day: r.day,
+      hour: r.hour,
+    };
+
+    // Always deliver to local SSE clients immediately.
+    bus.emit(EVENT_NAME, payload);
+
+    // Fan out to other instances via Redis when enabled.
+    if (isRedisEnabled()) {
+      ensureRedis();
+      if (publisher) {
+        publisher
+          .publish(CHANNEL, JSON.stringify({ origin: ORIGIN, payload }))
+          .catch((err) => console.error('[reservationEvents] redis publish failed:', err.message));
+      }
+    }
+  } catch (err) {
+    // Never let event delivery break a reservation write.
+    console.error('[reservationEvents] emit failed:', err.message);
+  }
+};
+
+const onReservationEvent = (handler) => bus.on(EVENT_NAME, handler);
+const offReservationEvent = (handler) => bus.off(EVENT_NAME, handler);
+
+module.exports = { emitReservationEvent, onReservationEvent, offReservationEvent };

--- a/src/routes/api/events_routes.js
+++ b/src/routes/api/events_routes.js
@@ -1,0 +1,81 @@
+// src/routes/api/events_routes.js
+// Server-Sent Events (SSE) stream for live reservation changes.
+//
+//   GET /api/events/reservations?token=<jwt>
+//
+// The admin agenda (frontend Diary.jsx) opens this stream and refreshes the
+// current week whenever a reservation is created / updated / deleted by anyone
+// (another admin, a user from the app), so the admin never has to reload.
+//
+// Auth note: the browser's native EventSource cannot send custom headers, so
+// it can't use the usual `Authorization: Bearer` flow. We accept the JWT as a
+// `token` query param and validate it here with the same verifyToken used by
+// the requireAuth middleware. This route is therefore NOT mounted behind the
+// global header-based requireAuth.
+
+const express = require('express');
+const router = express.Router();
+const { verifyToken } = require('../../lib/jwt');
+const { onReservationEvent, offReservationEvent } = require('../../lib/reservationEvents');
+
+const HEARTBEAT_MS = 25 * 1000;
+
+router.get('/events/reservations', (req, res) => {
+  // ---- Auth via query token (EventSource can't set headers) ----------------
+  const token = typeof req.query.token === 'string' ? req.query.token.trim() : '';
+  const result = verifyToken(token);
+  if (!result.ok) {
+    const status = result.reason === 'no-secret' ? 500 : 401;
+    return res.status(status).json({ message: 'No autenticado' });
+  }
+
+  // ---- SSE headers ---------------------------------------------------------
+  // `no-transform` makes the global compression() middleware skip this
+  // response (otherwise it would buffer the stream). X-Accel-Buffering: no
+  // tells reverse proxies (nginx / DO) not to buffer either.
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  });
+  res.flushHeaders();
+
+  // Initial comment so the client's connection opens immediately.
+  res.write(': connected\n\n');
+
+  // ---- Forward reservation events to this client ---------------------------
+  const send = (payload) => {
+    try {
+      res.write(`event: reservation\ndata: ${JSON.stringify(payload)}\n\n`);
+    } catch (err) {
+      // Write after close, etc. — drop the client.
+      cleanup();
+    }
+  };
+
+  onReservationEvent(send);
+
+  // ---- Heartbeat to keep the connection alive through the LB ---------------
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(': ping\n\n');
+    } catch (err) {
+      cleanup();
+    }
+  }, HEARTBEAT_MS);
+
+  // ---- Cleanup -------------------------------------------------------------
+  let cleanedUp = false;
+  function cleanup() {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    clearInterval(heartbeat);
+    offReservationEvent(send);
+  }
+
+  req.on('close', cleanup);
+  res.on('error', cleanup);
+});
+
+module.exports = router;


### PR DESCRIPTION
…alerts

- Add SSE stream GET /api/events/reservations (events_routes) so the admin agenda updates live; emit created/updated/deleted from the reservation controller via a new in-process event bus (reservationEvents) with optional Redis pub/sub fan-out for multi-instance.
- Add reusable notifyUser helper (bell inbox + best-effort web-push).
- Notify the user when the admin confirms a payment: monthly fee (finances) and store consumption (store), only on the No -> Si transition.
- Add daily membershipExpiryJob: remind users 2 days before their Mensual membership endDate (exact-date match avoids stale/old endDates; skips if already renewed).