### PR TITLE
feat(gamification): trophy showcase data + monthly constancy + achiev…

### DIFF
--- a/src/controllers/gamification_controller.js
+++ b/src/controllers/gamification_controller.js
@@ -11,7 +11,7 @@
 const moment = require('moment-timezone');
 const UserStreak = require('../models/userStreak');
 const UserNotification = require('../models/userNotification');
-const { computeStreak, buildCalendarMonth } = require('../services/gamificationService');
+const { computeStreak, buildCalendarMonth, getMonthlyAttendance, getTrophyStreakWeeks } = require('../services/gamificationService');
 
 const TZ = 'America/Bogota';
 
@@ -60,6 +60,33 @@ exports.getUserStreak = async (req, res) => {
   } catch (err) {
     console.error('[gamification] getUserStreak error:', err);
     return res.status(500).json({ message: 'Error al obtener racha' });
+  }
+};
+
+/**
+ * GET /api/gamification/:userId/progress?months=3
+ *
+ * One call powering the profile "Progreso" + "Trofeos" tabs:
+ *   - streak:  best/current streak (longestStreak drives trophy unlocks)
+ *   - monthly: attended sessions per month for the constancy chart
+ */
+exports.getUserProgress = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const months = Number(req.query.months) || 3;
+
+    let streak = await UserStreak.findOne({ userId }).lean();
+    if (!streak) {
+      streak = await computeStreak(userId);
+    }
+    const monthly = await getMonthlyAttendance(userId, months);
+    // Streak that counts only from the trophy launch date — drives medals.
+    const trophyWeeks = await getTrophyStreakWeeks(userId);
+
+    return res.json({ streak, monthly, trophyWeeks });
+  } catch (err) {
+    console.error('[gamification] getUserProgress error:', err);
+    return res.status(500).json({ message: 'Error al obtener el progreso' });
   }
 };
 

--- a/src/lib/trophies.js
+++ b/src/lib/trophies.js
@@ -1,0 +1,36 @@
+// src/lib/trophies.js
+// Trophy (achievement) definitions for the Bullfit "vitrina de trofeos".
+// A trophy is unlocked when the user's best streak (longestStreak, in WEEKS)
+// reaches `weeks`. Thresholds approximate months at ~52/12 weeks/month.
+//
+// Single source of truth on the backend (used to fire achievement
+// notifications when a milestone is newly crossed). The frontend TrophyCase
+// keeps a matching copy (with the medal artwork) — keep `key`/`weeks` in sync.
+
+// The trophy system goes live on this date (Bogotá). Before it, no medal
+// unlocks and no achievement notifications fire — everyone sees them locked.
+const TROPHIES_START = '2026-07-01';
+
+const TROPHIES = [
+  { key: 'iniciado', name: 'Iniciado', label: '1 mes', weeks: 4,
+    description: 'Completaste tu primer mes de constancia. ¡El comienzo de algo grande!' },
+  { key: 'constancia', name: 'Constancia', label: '2 meses', weeks: 9,
+    description: 'Dos meses entrenando sin fallar. Ya no es esfuerzo: es hábito.' },
+  { key: 'persistencia', name: 'Persistencia', label: '4 meses', weeks: 17,
+    description: 'Cuatro meses sin rendirte. La persistencia ya te define.' },
+  { key: 'seis_meses', name: '6 Meses', label: '6 meses', weeks: 26,
+    description: 'Medio año de disciplina pura. Eres imparable.' },
+  { key: 'nueve_meses', name: '9 Meses', label: '9 meses', weeks: 39,
+    description: 'Nueve meses de entrega total. Casi una leyenda Bullfit.' },
+  { key: 'un_ano', name: '1 Año', label: '1 año', weeks: 52,
+    description: '¡Un año completo de racha! Bienvenido a la élite Bullfit.' },
+];
+
+/**
+ * Trophies newly unlocked when longestStreak moves from `prevWeeks` to
+ * `newWeeks` (thresholds in the half-open range (prevWeeks, newWeeks]).
+ */
+const newlyUnlockedTrophies = (prevWeeks, newWeeks) =>
+  TROPHIES.filter((t) => t.weeks > (prevWeeks || 0) && t.weeks <= (newWeeks || 0));
+
+module.exports = { TROPHIES, TROPHIES_START, newlyUnlockedTrophies };

--- a/src/models/userStreak.js
+++ b/src/models/userStreak.js
@@ -26,6 +26,9 @@ const userStreakSchema = new mongoose.Schema(
     },
     currentStreak: { type: Number, default: 0 },
     longestStreak: { type: Number, default: 0 },
+    // Best streak counted ONLY from the trophy launch date (lib/trophies
+    // TROPHIES_START). Drives medal unlocks; separate from the all-time streak.
+    trophyLongestStreak: { type: Number, default: 0 },
     totalActivities: { type: Number, default: 0 }, // sessions in current streak
     streakStartDate: { type: String, default: null }, // YYYY-MM-DD
     lastAttendedDate: { type: String, default: null }, // YYYY-MM-DD

--- a/src/routes/api/gamification_routes.js
+++ b/src/routes/api/gamification_routes.js
@@ -18,6 +18,9 @@ router.get('/gamification/:userId', requireAuth, ctrl.getUserGamification);
 // GET /api/gamification/:userId/streak  (lightweight, for customer list cards)
 router.get('/gamification/:userId/streak', requireAuth, ctrl.getUserStreak);
 
+// GET /api/gamification/:userId/progress?months=3  (constancy chart + trophies)
+router.get('/gamification/:userId/progress', requireAuth, ctrl.getUserProgress);
+
 // ── Notification bell ────────────────────────────────────────────────────────
 // Order matters: put /read-all and /all before /:id to avoid route shadowing.
 

--- a/src/services/gamificationService.js
+++ b/src/services/gamificationService.js
@@ -17,8 +17,13 @@ const moment = require('moment-timezone');
 const Reservation = require('../models/reservations');
 const UserStreak = require('../models/userStreak');
 const { isBusinessDay } = require('../utils/colombianHolidays');
+const User = require('../models/users');
+const { newlyUnlockedTrophies, TROPHIES_START } = require('../lib/trophies');
+const { notifyUser } = require('../lib/notifyUser');
 
 const TZ = 'America/Bogota';
+
+const MONTH_LABELS_ES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -46,10 +51,14 @@ function weekKey(dateStr) {
  * @returns {Object} { currentStreak, longestStreak, totalActivities,
  *                     streakStartDate, lastAttendedDate }
  */
-async function computeStreak(userId) {
-  // Fetch ALL attended reservations, oldest first.
+async function computeStreak(userId, sinceDay = null) {
+  // Fetch attended reservations, oldest first. When `sinceDay` is given
+  // (YYYY-MM-DD), only count attendance on/after it — used for the trophy
+  // streak, which starts counting from the launch date.
+  const query = { userId, Attendance: 'Si' };
+  if (sinceDay) query.day = { $gte: sinceDay };
   const attended = await Reservation.find(
-    { userId, Attendance: 'Si' },
+    query,
     { day: 1, _id: 0 },
   ).sort({ day: 1 }).lean();
 
@@ -191,18 +200,113 @@ async function computeStreak(userId) {
  * Called after every attendance update.
  */
 async function updateUserStreak(userId) {
+  // Capture the previous trophy streak so we can detect newly-crossed trophy
+  // thresholds after recomputing.
+  const existing = await UserStreak.findOne(
+    { userId },
+    { trophyLongestStreak: 1 },
+  ).lean();
+  const prevTrophy = existing ? (existing.trophyLongestStreak || 0) : 0;
+
+  // All-time streak (drives the calendar / "mejor racha").
   const data = await computeStreak(userId);
+  // Trophy streak: only counts from the launch date.
+  const trophyData = await computeStreak(userId, TROPHIES_START);
+  const trophyLongest = trophyData.longestStreak || 0;
+
   const streakDoc = await UserStreak.findOneAndUpdate(
     { userId },
     {
       $set: {
         ...data,
+        trophyLongestStreak: trophyLongest,
         lastComputedAt: new Date(),
       },
     },
     { upsert: true, new: true, setDefaultsOnInsert: true },
   );
+
+  // Celebrate any trophy whose threshold the user just crossed — but only once
+  // the trophy system is live (TROPHIES_START). Before that, no unlock fires.
+  const trophiesLive = moment.tz(TZ).format('YYYY-MM-DD') >= TROPHIES_START;
+  const unlocked = trophiesLive ? newlyUnlockedTrophies(prevTrophy, trophyLongest) : [];
+
+  if (unlocked.length) {
+    // Resolve the achiever's name and the admin list once for this batch.
+    let userName = '';
+    let admins = [];
+    try {
+      const u = await User.findById(userId).select('FirstName LastName').lean();
+      if (u) userName = `${u.FirstName || ''} ${u.LastName || ''}`.trim();
+      admins = await User.find({ role: 'admin' }).select('_id').lean();
+    } catch (err) {
+      console.error('[gamification] trophy notify lookup failed:', err.message);
+    }
+
+    for (const t of unlocked) {
+      // → the user who unlocked it
+      notifyUser(userId, {
+        title: '¡Nuevo trofeo! 🏆',
+        body: `Desbloqueaste "${t.name}" (${t.label} de racha). ${t.description}`,
+        url: '/#trofeos',
+        type: 'achievement',
+        dedupeKey: `trophy-${userId}-${t.key}`,
+      }).catch((err) => console.error('[gamification] trophy notify failed:', err.message));
+
+      // → every admin
+      for (const a of admins) {
+        notifyUser(a._id, {
+          title: 'Medalla desbloqueada 🏆',
+          body: `${userName || 'Un usuario'} desbloqueó "${t.name}" (${t.label} de racha).`,
+          url: '/',
+          type: 'achievement',
+          dedupeKey: `trophy-admin-${a._id}-${userId}-${t.key}`,
+        }).catch((err) => console.error('[gamification] admin trophy notify failed:', err.message));
+      }
+    }
+  }
+
   return streakDoc;
+}
+
+// ─── Monthly Attendance (constancy chart) ────────────────────────────────────
+
+/**
+ * Count attended sessions per calendar month for the last `months` months
+ * (including the current one), oldest first. Used by the profile constancy
+ * chart.
+ *
+ * @param {string} userId
+ * @param {number} months  - how many months back (default 3, max 12)
+ * @returns {Promise<Array<{ month: string, label: string, attended: number }>>}
+ */
+async function getMonthlyAttendance(userId, months = 3) {
+  const n = Math.max(1, Math.min(Number(months) || 3, 12));
+  const now = moment.tz(TZ);
+
+  // Build empty buckets for the last n months, chronological.
+  const buckets = [];
+  const indexByMonth = {};
+  for (let i = n - 1; i >= 0; i--) {
+    const m = now.clone().subtract(i, 'months');
+    const ym = m.format('YYYY-MM');
+    indexByMonth[ym] = buckets.length;
+    buckets.push({ month: ym, label: MONTH_LABELS_ES[m.month()], attended: 0 });
+  }
+
+  const startDay = `${buckets[0].month}-01`;
+  const attended = await Reservation.find(
+    { userId, Attendance: 'Si', day: { $gte: startDay } },
+    { day: 1, _id: 0 },
+  ).lean();
+
+  for (const r of attended) {
+    const ym = (r.day || '').slice(0, 7);
+    const idx = indexByMonth[ym];
+    if (idx !== undefined) buckets[idx].attended += 1;
+  }
+
+  return buckets;
 }
 
 // ─── Calendar Builder ────────────────────────────────────────────────────────
@@ -303,8 +407,19 @@ async function buildCalendarMonth(userId, year, month) {
   return { year: Number(year), month: Number(month), weeks };
 }
 
+/**
+ * Best streak (in weeks) counted only from the trophy launch date.
+ * Drives which medals are unlocked. Returns 0 before the launch date.
+ */
+async function getTrophyStreakWeeks(userId) {
+  const s = await computeStreak(userId, TROPHIES_START);
+  return s.longestStreak || 0;
+}
+
 module.exports = {
   computeStreak,
   updateUserStreak,
   buildCalendarMonth,
+  getMonthlyAttendance,
+  getTrophyStreakWeeks,
 };


### PR DESCRIPTION
…ement notifications

- Add GET /api/gamification/:userId/progress returning monthly attendance (constancy chart) + trophyWeeks (streak that counts only from the launch date) in one call.
- computeStreak now accepts a sinceDay filter; add getMonthlyAttendance and getTrophyStreakWeeks. Persist trophyLongestStreak on UserStreak.
- On crossing a trophy threshold, notify the user AND every admin (bell inbox
  + push), deduped per trophy. Gated to TROPHIES_START (2026-07-01): before that, no medal unlocks and no notifications; streaks for medals start counting that day.