### PR TITLE
feat(rachas): el juego arranca desde cero el 1 de julio + textos de t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "jest",
     "dev": "npx nodemon app",
     "start": "node app",
-    "update-db": "node update.js"
+    "update-db": "node update.js",
+    "reset-streaks": "node src/scripts/resetStreaks.js"
   },
   "author": "santiago murillo",
   "license": "ISC",

--- a/src/lib/trophies.js
+++ b/src/lib/trophies.js
@@ -13,17 +13,17 @@ const TROPHIES_START = '2026-07-01';
 
 const TROPHIES = [
   { key: 'iniciado', name: 'Iniciado', label: '1 mes', weeks: 4,
-    description: 'Completaste tu primer mes de constancia. ¡El comienzo de algo grande!' },
+    description: 'Arrancaste con todo y no fallaste. ¡El comienzo de algo grande!' },
   { key: 'constancia', name: 'Constancia', label: '2 meses', weeks: 9,
-    description: 'Dos meses entrenando sin fallar. Ya no es esfuerzo: es hábito.' },
+    description: 'Entrenar sin fallar ya no es esfuerzo: es hábito.' },
   { key: 'persistencia', name: 'Persistencia', label: '4 meses', weeks: 17,
-    description: 'Cuatro meses sin rendirte. La persistencia ya te define.' },
+    description: 'No te rendiste. Ya es parte de quién eres.' },
   { key: 'seis_meses', name: '6 Meses', label: '6 meses', weeks: 26,
-    description: 'Medio año de disciplina pura. Eres imparable.' },
+    description: 'Disciplina pura, sin excusas. Eres imparable.' },
   { key: 'nueve_meses', name: '9 Meses', label: '9 meses', weeks: 39,
-    description: 'Nueve meses de entrega total. Casi una leyenda Bullfit.' },
+    description: 'Entrega total, sin pausa. Casi una leyenda Bullfit.' },
   { key: 'un_ano', name: '1 Año', label: '1 año', weeks: 52,
-    description: '¡Un año completo de racha! Bienvenido a la élite Bullfit.' },
+    description: '¡Lo lograste! Bienvenido a la élite Bullfit.' },
 ];
 
 /**

--- a/src/scripts/resetStreaks.js
+++ b/src/scripts/resetStreaks.js
@@ -1,0 +1,72 @@
+// src/scripts/resetStreaks.js
+//
+// Reset de un solo uso para el ARRANQUE del juego de rachas (1 de julio 2026).
+// Hace dos cosas, en silencio (NO envía ninguna notificación a nadie):
+//   1. Pone en cero la cuenta de racha GUARDADA de todos los usuarios.
+//   2. Quita TODOS los trofeos otorgados (notificaciones type:'achievement' con
+//      trophyKey) — el juego aún no empieza, así que todos parten sin medallas.
+//
+// ¿Cuándo correrlo? Una sola vez, al lanzar el juego (1 jul). En esa fecha nadie
+// tiene aún asistencias dentro del juego, así que poner todo en cero == recalcular.
+//
+// Notas:
+//   - Las medallas POR RACHA (1 mes … 1 año) son calculadas en vivo, no se guardan.
+//     Con el piso de fecha en gamificationService (computeStreak /
+//     computeStreakFromDays) ya quedan bloqueadas para todos hasta el 1 de julio,
+//     así que no hay nada que borrar para esas.
+//   - Borrar documentos NO dispara notificaciones: el usuario simplemente deja de
+//     ver el trofeo / la racha.
+//
+// Uso:  node src/scripts/resetStreaks.js     (o: npm run reset-streaks)
+
+const mongoose = require('mongoose');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const UserStreak = require('../models/userStreak');
+const UserNotification = require('../models/userNotification');
+
+async function main() {
+  const dbUrl = process.env.MONGODB_URL;
+  if (!dbUrl) {
+    console.error('Falta MONGODB_URL en el entorno (.env). Abortando.');
+    process.exit(1);
+  }
+
+  await mongoose.connect(dbUrl, { serverSelectionTimeoutMS: 5000 });
+  console.log('Conectado a MongoDB.');
+
+  // 1) Racha guardada → cero para todos.
+  const streakRes = await UserStreak.updateMany(
+    {},
+    {
+      $set: {
+        currentStreak: 0,
+        longestStreak: 0,
+        trophyLongestStreak: 0,
+        totalActivities: 0,
+        streakStartDate: null,
+        lastAttendedDate: null,
+        lastComputedAt: new Date(),
+      },
+    },
+  );
+  console.log(`Rachas reseteadas a cero: ${streakRes.modifiedCount} usuario(s).`);
+
+  // 2) Trofeos otorgados → fuera (borrado silencioso, sin notificar).
+  const trophyRes = await UserNotification.deleteMany({
+    type: 'achievement',
+    trophyKey: { $exists: true, $ne: null },
+  });
+  console.log(`Trofeos otorgados eliminados: ${trophyRes.deletedCount}.`);
+
+  await mongoose.disconnect();
+  console.log('Listo. El juego de rachas arranca desde cero, sin medallas, el 1 de julio.');
+}
+
+main().catch(async (err) => {
+  console.error('Error en el reset:', err);
+  try { await mongoose.disconnect(); } catch (_) { /* noop */ }
+  process.exit(1);
+});

--- a/src/services/gamificationService.js
+++ b/src/services/gamificationService.js
@@ -66,7 +66,8 @@ function computeStreakFromDays(attendedDays) {
   const todayKey = weekKey(today);
   const weekMap = {};
   for (const day of attendedDays) {
-    if (day > today) continue; // ignorar reservas futuras
+    if (day > today) continue;            // ignorar reservas futuras (las medallas/racha nunca cuentan el futuro)
+    if (day < TROPHIES_START) continue;   // el juego de rachas arranca en la fecha de lanzamiento: todos parten de cero
     if (!isBusinessDay(day)) continue;
     const k = weekKey(day);
     if (!weekMap[k]) weekMap[k] = new Set();
@@ -107,12 +108,14 @@ function computeStreakFromDays(attendedDays) {
  *                     streakStartDate, lastAttendedDate }
  */
 async function computeStreak(userId, sinceDay = null) {
-  // Fetch attended reservations, oldest first. When `sinceDay` is given
-  // (YYYY-MM-DD), only count attendance on/after it — used for the trophy
-  // streak, which starts counting from the launch date.
+  // Fetch attended reservations, oldest first.
+  //  - `day <= today` => las medallas/racha NUNCA cuentan reservas futuras.
+  //  - `day >= floor` => toda la racha arranca en la fecha de lanzamiento del
+  //    juego (TROPHIES_START): todos parten de cero el 1 de julio. `sinceDay`,
+  //    si se pasa, solo puede mover el piso hacia adelante, nunca antes.
   const today = moment.tz(TZ).format('YYYY-MM-DD');
-  const query = { userId, Attendance: { $ne: 'No' }, day: { $lte: today } };
-  if (sinceDay) query.day.$gte = sinceDay;
+  const floorDay = sinceDay && sinceDay > TROPHIES_START ? sinceDay : TROPHIES_START;
+  const query = { userId, Attendance: { $ne: 'No' }, day: { $gte: floorDay, $lte: today } };
   const attended = await Reservation.find(
     query,
     { day: 1, _id: 0 },
@@ -221,11 +224,11 @@ async function updateUserStreak(userId) {
   ).lean();
   const prevTrophy = existing ? (existing.trophyLongestStreak || 0) : 0;
 
-  // All-time streak (drives the calendar / "mejor racha").
+  // Streak shown in the calendar / "mejor racha". Since computeStreak now floors
+  // every streak at the launch date (TROPHIES_START), the displayed streak and
+  // the trophy streak coincide — no need to compute it twice.
   const data = await computeStreak(userId);
-  // Trophy streak: only counts from the launch date.
-  const trophyData = await computeStreak(userId, TROPHIES_START);
-  const trophyLongest = trophyData.longestStreak || 0;
+  const trophyLongest = data.longestStreak || 0;
 
   const streakDoc = await UserStreak.findOneAndUpdate(
     { userId },
@@ -260,7 +263,7 @@ async function updateUserStreak(userId) {
       // → the user who unlocked it
       notifyUser(userId, {
         title: '¡Nuevo trofeo! 🏆',
-        body: `Desbloqueaste "${t.name}" (${t.label} de racha). ${t.description}`,
+        body: `Desbloqueaste el trofeo "${t.name}". ${t.description}`,
         url: '/#trofeos',
         type: 'achievement',
         dedupeKey: `trophy-${userId}-${t.key}`,
@@ -270,7 +273,7 @@ async function updateUserStreak(userId) {
       for (const a of admins) {
         notifyUser(a._id, {
           title: 'Medalla desbloqueada 🏆',
-          body: `${userName || 'Un usuario'} desbloqueó "${t.name}" (${t.label} de racha).`,
+          body: `${userName || 'Un usuario'} desbloqueó el trofeo "${t.name}".`,
           url: '/',
           type: 'achievement',
           dedupeKey: `trophy-admin-${a._id}-${userId}-${t.key}`,


### PR DESCRIPTION
…rofeos

- computeStreak/computeStreakFromDays cuentan la racha solo desde TROPHIES_START (toda la racha, no solo los trofeos): todos parten de cero el 1 de julio.
- Reafirma y comenta que las medallas/racha nunca cuentan reservas futuras (filtro day <= hoy).
- Unifica la racha mostrada y la de trofeos (mismo epoch) y evita el doble cálculo en updateUserStreak.
- Notificaciones de trofeo sin repetir nombre/duración.
- Script de un solo uso 'reset-streaks': pone las rachas en cero y borra los trofeos otorgados, en silencio (borrar no envía notificaciones).